### PR TITLE
Fix for #1513 and change some wording in the report

### DIFF
--- a/realtime/shake_event.py
+++ b/realtime/shake_event.py
@@ -902,7 +902,7 @@ class ShakeEvent(QObject):
         header = TableRow([
             '',
             self.tr('Name'),
-            self.tr('People Affected (x 1000)'),
+            self.tr('Population (x 1000)'),
             self.tr('Intensity')],
             header=True)
         for row_data in table_data:
@@ -1559,7 +1559,7 @@ class ShakeEvent(QObject):
             upper_limit = math.pow(upper_limit, 2)
         fatalities_range = '%i - %i' % (lower_limit, upper_limit)
 
-        city_table_name = self.tr('Places Affected')
+        city_table_name = self.tr('Nearby Places')
         legend_name = self.tr('Population count per grid cell')
         limitations = self.tr(
             'This impact estimation is automatically generated and only takes'

--- a/realtime/shake_event.py
+++ b/realtime/shake_event.py
@@ -584,11 +584,12 @@ class ShakeEvent(QObject):
                 # position not found on raster
                 continue
             value = raster_values[0]  # Band 1
+
             LOGGER.debug('Raster Value: %s' % value)
-            if 'no data' not in str(value):
-                mmi = float(value)
-            else:
+            if 'no data' in str(value) or value is None:
                 mmi = 0
+            else:
+                mmi = float(value)
 
             LOGGER.debug(
                 'Looked up mmi of %s on raster for %s' % (mmi, str(point)))

--- a/realtime/test/test_shake_event.py
+++ b/realtime/test/test_shake_event.py
@@ -353,7 +353,7 @@ class TestShakeEvent(unittest.TestCase):
             'exposure-table-name': u'Estimated number of people '
                                    u'affected by each MMI level',
             'longitude-value': u'140\xb037\'12.00"E',
-            'city-table-name': u'Places Affected',
+            'city-table-name': u'Nearby Places',
             'bearing-text': u'bearing',
             'limitations': (
                 u'This impact estimation is automatically generated and only '


### PR DESCRIPTION
The mmi-nearest.tif generated has no "No Data" value set.

* As we try to get the value of the mmi given a point, there might be a case when the point is not in the raster, or it lies on the pixel which value is "No Data".
* We don't assess population affected for each nearby cities. This commit changes the title from 'Places Affected' to 'Nearby Places' and from 'People Affected' to 'Population' for each nearby cities.

Signed-off-by: Akbar Gumbira <akbargumbira@gmail.com>