### PR TITLE
Line endings normalization rule in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,21 @@
 *.py export-subst
+
+# Declare default as text files and have LF line endings
+* text eol=lf
+
+# Declare files that will always have CRLF line endings
+*.bat text eol=crlf
+
+# Declare files that is not a text
+# images:
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.idraw binary
+*.xcf binary
+
+# fonts:
+*.eot
+*.ttf
+*.woff


### PR DESCRIPTION
Regarding Issue  #660

Add some attributes in .gitattributes.
The following are expected after this fix:
1. When Windows user doing a checkout, the line endings will follow the rule in their repository (core.autocrlf)
2. When Windows user doing a commit or push, the line endings will follow Unix style (LF), except for *.bat files (always CRLF)
3. Some of the files are set as binary to avoid falsely attributed as text, like images and fonts.
