### PR TITLE
fix #1423 save .xml and .keywords when using 'saved as'

### DIFF
--- a/safe/gis/qgis_interface.py
+++ b/safe/gis/qgis_interface.py
@@ -28,7 +28,7 @@ __copyright__ = (
 
 import logging
 
-from qgis.core import QgsMapLayerRegistry, QGis
+from qgis.core import QgsMapLayerRegistry, QGis, QgsMapLayer
 from qgis.gui import QgsMapCanvasLayer  # pylint: disable=no-name-in-module
 from PyQt4.QtCore import QObject, pyqtSlot, pyqtSignal
 LOGGER = logging.getLogger('InaSAFE')
@@ -42,6 +42,7 @@ class QgisInterface(QObject):
     so most methods are simply stubs.
     """
     currentLayerChanged = pyqtSignal(QgsMapCanvasLayer)
+    layerSavedAs = pyqtSignal(QgsMapLayer, str)
 
     def __init__(self, canvas):
         """Constructor

--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -567,15 +567,15 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
 
     @pyqtSlot(QgsMapLayer, str)
     def save_auxiliary_files(self, layer, destination):
-        """Save auxiliary files when using the saved as function.
+        """Save auxiliary files when using the 'save as' function.
 
         If some auxiliary files (.xml or .keywords) exist, this function will copy them
-        when the saved as function is used on the layer.
+        when the 'save as' function is used on the layer.
 
         :param layer: The layer which has been saved as.
         :type layer: QgsMapLayer
 
-        :param destination: The new filename of the layer
+        :param destination: The new filename of the layer.
         :type str
 
         """
@@ -588,19 +588,20 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         destination_keywords = "%s.keywords" % destination_basename
         destination_xml = "%s.xml" % destination_basename
 
-        #Keywords
-        if os.path.isfile(destination_keywords):
-            os.remove(destination_keywords)
+        try :
+            #Keywords
+            if os.path.isfile(source_keywords):
+                shutil.copy(source_keywords,destination_keywords)
 
-        if os.path.isfile(source_keywords):
-            shutil.copy(source_keywords,destination_keywords)
-
-        #XML
-        if os.path.isfile(destination_xml):
-            os.remove(destination_xml)
-
-        if os.path.isfile(source_xml):
-            shutil.copy(source_xml,destination_xml)
+            #XML
+            if os.path.isfile(source_xml):
+                shutil.copy(source_xml,destination_xml)
+                
+        except OSError, e:
+            self.show_error_message(self.tr("The destination location must be writable."))
+        except Exception, e:
+            message = get_error_message(e, context=message)
+            self.show_error_message(message)
 
     # noinspection PyPep8Naming
     @pyqtSlot(int)

--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -19,6 +19,7 @@ __copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
                  'Disaster Reduction')
 
 import os
+import shutil
 import logging
 from functools import partial
 
@@ -28,7 +29,8 @@ from qgis.core import (
     QgsRectangle,
     QgsMapLayer,
     QgsMapLayerRegistry,
-    QgsCoordinateReferenceSystem)
+    QgsCoordinateReferenceSystem,
+    QGis)
 # noinspection PyPackageRequirements
 from PyQt4 import QtGui, QtCore
 # noinspection PyPackageRequirements
@@ -175,6 +177,9 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         self.runtime_keywords_dialog = None
 
         self.setup_button_connectors()
+
+        if QGis.QGIS_VERSION_INT >= 20700:
+            self.iface.layerSavedAs.connect(self.save_auxiliary_files)
 
         canvas = self.iface.mapCanvas()
 
@@ -559,6 +564,43 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         else:
             message = self.ready_message()
             return True, message
+
+    @pyqtSlot(QgsMapLayer, str)
+    def save_auxiliary_files(self, layer, destination):
+        """Save auxiliary files when using the saved as function.
+
+        If some auxiliary files (.xml or .keywords) exist, this function will copy them
+        when the saved as function is used on the layer.
+
+        :param layer: The layer which has been saved as.
+        :type layer: QgsMapLayer
+
+        :param destination: The new filename of the layer
+        :type str
+
+        """
+
+        source_basename = os.path.splitext(layer.source())[0]
+        source_keywords = "%s.keywords" % source_basename
+        source_xml = "%s.xml" % source_basename
+
+        destination_basename = os.path.splitext(destination)[0]
+        destination_keywords = "%s.keywords" % destination_basename
+        destination_xml = "%s.xml" % destination_basename
+
+        #Keywords
+        if os.path.isfile(destination_keywords):
+            os.remove(destination_keywords)
+
+        if os.path.isfile(source_keywords):
+            shutil.copy(source_keywords,destination_keywords)
+
+        #XML
+        if os.path.isfile(destination_xml):
+            os.remove(destination_xml)
+
+        if os.path.isfile(source_xml):
+            shutil.copy(source_xml,destination_xml)
 
     # noinspection PyPep8Naming
     @pyqtSlot(int)

--- a/safe/gui/widgets/test/test_dock.py
+++ b/safe/gui/widgets/test/test_dock.py
@@ -32,7 +32,7 @@ from qgis.core import (
     QgsCoordinateReferenceSystem)
 from PyQt4 import QtCore
 
-from safe.common.utilities import format_int
+from safe.common.utilities import format_int, unique_filename
 from safe.test.utilities import (
     test_data_path,
     load_standard_layers,
@@ -631,6 +631,36 @@ class TestDock(TestCase):
             html,
             expected)
         self.assertTrue(expected in html, message)
+
+    def test_layer_saved_as_with_keywords_and_xml(self):
+        """Check that auxiliary files are well copied when they exist and the 'saved as' is used."""
+
+        layer_path = os.path.join(TESTDATA, 'tsunami_building_assessment.shp')
+        layer, layer_type = load_layer(layer_path)
+
+        new_name = unique_filename(prefix = 'tsunami_building_assessment_saved_as_')
+        DOCK.save_auxiliary_files(layer,join(TESTDATA, '%s.shp' % new_name))
+        new_keywords_filepath = os.path.join(TESTDATA, '%s.keywords' % new_name)
+        new_xml_filepath = os.path.join(TESTDATA, '%s.xml' % new_name)
+
+        message = 'New auxiliary file does not exist : '
+        self.assertTrue(os.path.isfile(new_keywords_filepath), '%s keywords' % message)
+        self.assertTrue(os.path.isfile(new_xml_filepath), '%s xml' % message)
+
+    def test_layer_saved_as_without_keywords_and_xml(self):
+        """Check that auxiliary files aren't created when they don't exist and the 'saved as' is used."""
+
+        layer_path = os.path.join(TESTDATA, 'kecamatan_jakarta_osm.shp')
+        layer, layer_type = load_layer(layer_path)
+
+        new_name = unique_filename(prefix = 'kecamatan_jakarta_osm_saved_as')
+        DOCK.save_auxiliary_files(layer,join(TESTDATA, '%s.shp' % new_name))
+        new_keywords_filepath = os.path.join(TESTDATA, '%s.keywords' % new_name)
+        new_xml_filepath = os.path.join(TESTDATA, '%s.xml' % new_name)
+
+        message = 'New auxiliary file exist : '
+        self.assertFalse(os.path.isfile(new_keywords_filepath), '%s keywords' % message)
+        self.assertFalse(os.path.isfile(new_xml_filepath), '%s xml' % message)
 
     def test_new_layers_show_in_canvas(self):
         """Check that when we add a layer we can see it in the canvas list."""


### PR DESCRIPTION
fix #1423 
When we use the "saved as" function on a layer, .xml and .keywords are also saved