### PR TITLE
fix #1423 save .xml and .keywords when using 'save as'

### DIFF
--- a/safe/gis/qgis_interface.py
+++ b/safe/gis/qgis_interface.py
@@ -28,7 +28,7 @@ __copyright__ = (
 
 import logging
 
-from qgis.core import QgsMapLayerRegistry, QGis
+from qgis.core import QgsMapLayerRegistry, QGis, QgsMapLayer
 from qgis.gui import QgsMapCanvasLayer  # pylint: disable=no-name-in-module
 from PyQt4.QtCore import QObject, pyqtSlot, pyqtSignal
 LOGGER = logging.getLogger('InaSAFE')
@@ -42,6 +42,7 @@ class QgisInterface(QObject):
     so most methods are simply stubs.
     """
     currentLayerChanged = pyqtSignal(QgsMapCanvasLayer)
+    layerSavedAs = pyqtSignal(QgsMapLayer, str)
 
     def __init__(self, canvas):
         """Constructor

--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -489,8 +489,8 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             self.tr('Ready'), **PROGRESS_UPDATE_STYLE)
         notes = m.Paragraph(self.tr(
             'You can now proceed to run your model by clicking the'),
-                            m.EmphasizedText(self.tr('Run'), **KEYWORD_STYLE),
-                            self.tr('button.'))
+            m.EmphasizedText(self.tr('Run'), **KEYWORD_STYLE),
+            self.tr('button.'))
         message = m.Message(LOGO_ELEMENT, title, notes)
         return message
 
@@ -594,17 +594,17 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             if os.path.isfile(source_keywords):
                 shutil.copy(source_keywords, destination_keywords)
 
-            #XML
+            # XML
             if os.path.isfile(source_xml):
                 shutil.copy(source_xml, destination_xml)
 
         except (OSError, IOError):
-            display_critical_message_bar(title=self.tr('Error while saving'),
-                                         message=self.tr("The destination location must be writable."))
+            display_critical_message_bar(
+                title=self.tr('Error while saving'), message=self.tr("The destination location must be writable."))
 
         except Exception:
-            display_critical_message_bar(title=self.tr('Error while saving'),
-                                         message=self.tr("Something went wrong."))
+            display_critical_message_bar(
+                title=self.tr('Error while saving'), message=self.tr("Something went wrong."))
 
     # noinspection PyPep8Naming
     @pyqtSlot(int)

--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -49,6 +49,7 @@ from safe.utilities.resources import (
     resources_path,
     resource_url,
     get_ui_class)
+from safe.utilities.qgis_utilities import display_critical_message_bar
 from safe.defaults import (
     limitations,
     default_organisation_logo_path)
@@ -488,8 +489,8 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             self.tr('Ready'), **PROGRESS_UPDATE_STYLE)
         notes = m.Paragraph(self.tr(
             'You can now proceed to run your model by clicking the'),
-            m.EmphasizedText(self.tr('Run'), **KEYWORD_STYLE),
-            self.tr('button.'))
+                            m.EmphasizedText(self.tr('Run'), **KEYWORD_STYLE),
+                            self.tr('button.'))
         message = m.Message(LOGO_ELEMENT, title, notes)
         return message
 
@@ -588,20 +589,22 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         destination_keywords = "%s.keywords" % destination_basename
         destination_xml = "%s.xml" % destination_basename
 
-        try :
-            #Keywords
+        try:
+            # Keywords
             if os.path.isfile(source_keywords):
-                shutil.copy(source_keywords,destination_keywords)
+                shutil.copy(source_keywords, destination_keywords)
 
             #XML
             if os.path.isfile(source_xml):
-                shutil.copy(source_xml,destination_xml)
-                
-        except OSError, e:
-            self.show_error_message(self.tr("The destination location must be writable."))
-        except Exception, e:
-            message = get_error_message(e, context=message)
-            self.show_error_message(message)
+                shutil.copy(source_xml, destination_xml)
+
+        except (OSError, IOError):
+            display_critical_message_bar(title=self.tr('Error while saving'),
+                                         message=self.tr("The destination location must be writable."))
+
+        except Exception:
+            display_critical_message_bar(title=self.tr('Error while saving'),
+                                         message=self.tr("Something went wrong."))
 
     # noinspection PyPep8Naming
     @pyqtSlot(int)
@@ -773,7 +776,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             return
 
         # for arg in args:
-        #    LOGGER.debug('get_layer argument: %s' % arg)
+        # LOGGER.debug('get_layer argument: %s' % arg)
         # Map registry may be invalid if QGIS is shutting down
         registry = QgsMapLayerRegistry.instance()
         canvas_layers = self.iface.mapCanvas().layers()
@@ -1184,6 +1187,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
         # Try to run completion code
         try:
             from datetime import datetime
+
             LOGGER.debug(datetime.now())
             LOGGER.debug('get engine impact layer')
             LOGGER.debug(self.analysis is None)
@@ -1203,7 +1207,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             impact_path = qgis_impact_layer.source()
             message = m.Message(report)
             # message.add(m.Heading(self.tr('View processing log as HTML'),
-            #                      **INFO_STYLE))
+            # **INFO_STYLE))
             # message.add(m.Link('file://%s' % self.wvResults.log_path))
             self.show_static_message(message)
             self.wvResults.impact_path = impact_path
@@ -1263,14 +1267,14 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
             if not style:
                 qgis_impact_layer.setDrawingStyle("SingleBandPseudoColor")
                 # qgis_impact_layer.setColorShadingAlgorithm(
-                #    QgsRasterLayer.PseudoColorShader)
+                # QgsRasterLayer.PseudoColorShader)
             else:
                 setRasterStyle(qgis_impact_layer, style)
 
         else:
             message = self.tr(
                 'Impact layer %s was neither a raster or a vector layer') % (
-                    qgis_impact_layer.source())
+                qgis_impact_layer.source())
             # noinspection PyExceptionInherit
             raise ReadLayerError(message)
 

--- a/safe/gui/widgets/test/test_dock.py
+++ b/safe/gui/widgets/test/test_dock.py
@@ -32,7 +32,7 @@ from qgis.core import (
     QgsCoordinateReferenceSystem)
 from PyQt4 import QtCore
 
-from safe.common.utilities import format_int
+from safe.common.utilities import format_int, unique_filename
 from safe.test.utilities import (
     test_data_path,
     load_standard_layers,
@@ -631,6 +631,36 @@ class TestDock(TestCase):
             html,
             expected)
         self.assertTrue(expected in html, message)
+
+    def test_layer_saved_as_with_keywords_and_xml(self):
+        """Check that auxiliary files are well copied when they exist and the 'saved as' is used."""
+
+        layer_path = os.path.join(TESTDATA, 'tsunami_building_assessment.shp')
+        layer, layer_type = load_layer(layer_path)
+
+        new_name = unique_filename(prefix = 'tsunami_building_assessment_saved_as_')
+        DOCK.save_auxiliary_files(layer,join(TESTDATA, '%s.shp' % new_name))
+        new_keywords_filepath = os.path.join(TESTDATA, '%s.keywords' % new_name)
+        new_xml_filepath = os.path.join(TESTDATA, '%s.xml' % new_name)
+
+        message = 'New auxiliary file does not exist : '
+        self.assertTrue(os.path.isfile(new_keywords_filepath), '%s keywords' % message)
+        self.assertTrue(os.path.isfile(new_xml_filepath), '%s xml' % message)
+
+    def test_layer_saved_as_without_keywords_and_xml(self):
+        """Check that auxiliary files aren't created when they don't exist and the 'saved as' is used."""
+
+        layer_path = os.path.join(TESTDATA, 'kecamatan_jakarta_osm.shp')
+        layer, layer_type = load_layer(layer_path)
+
+        new_name = unique_filename(prefix = 'kecamatan_jakarta_osm_saved_as')
+        DOCK.save_auxiliary_files(layer,join(TESTDATA, '%s.shp' % new_name))
+        new_keywords_filepath = os.path.join(TESTDATA, '%s.keywords' % new_name)
+        new_xml_filepath = os.path.join(TESTDATA, '%s.xml' % new_name)
+
+        message = 'New auxiliary file exist : '
+        self.assertFalse(os.path.isfile(new_keywords_filepath), '%s keywords' % message)
+        self.assertFalse(os.path.isfile(new_xml_filepath), '%s xml' % message)
 
     def test_new_layers_show_in_canvas(self):
         """Check that when we add a layer we can see it in the canvas list."""

--- a/safe/utilities/qgis_utilities.py
+++ b/safe/utilities/qgis_utilities.py
@@ -184,7 +184,7 @@ def display_critical_message_bar(
         button = QPushButton(widget)
         button.setText(button_text)
         button.pressed.connect(
-            lambda: display_warning_message_box(title, more_details)
+            lambda: display_critical_message_box(title, more_details)
         )
         widget.layout().addWidget(button)
 

--- a/safe/utilities/qgis_utilities.py
+++ b/safe/utilities/qgis_utilities.py
@@ -1,0 +1,77 @@
+# coding=utf-8
+"""
+QGIS utilities for InaSAFE
+"""
+
+__author__ = 'etienne'
+
+from qgis.gui import QgsMessageBar
+from qgis.utils import iface
+
+
+def display_information_message_bar(title=None, message=None, duration=8):
+    """
+    Display a information message bar.
+
+    :param title The title of the message bar.
+    :type title str
+
+    :param message The message inside the message bar.
+    :type message str
+
+    :param duration The duration for the display, default is 8 seconds.
+    :type duration int
+    """
+
+    iface.messageBar().pushMessage(title, message, QgsMessageBar.INFO, duration)
+
+
+def display_critical_message_bar(title=None, message=None, duration=8):
+    """
+    Display a critical message bar.
+
+    :param title The title of the message bar.
+    :type title str
+
+    :param message The message inside the message bar.
+    :type message str
+
+    :param duration The duration for the display, default is 8 seconds.
+    :type duration int
+    """
+
+    iface.messageBar().pushMessage(title, message, QgsMessageBar.CRITICAL, duration)
+
+
+def display_warning_message_bar(title=None, message=None, duration=8):
+    """
+    Display a warning message bar.
+
+    :param title The title of the message bar.
+    :type title str
+
+    :param message The message inside the message bar.
+    :type message str
+
+    :param duration The duration for the display, default is 8 seconds.
+    :type duration int
+    """
+
+    iface.messageBar().pushMessage(title, message, QgsMessageBar.WARNING, duration)
+
+
+def display_success_message_bar(title=None, message=None, duration=8):
+    """
+    Display a success message bar.
+
+    :param title The title of the message bar.
+    :type title str
+
+    :param message The message inside the message bar.
+    :type message str
+
+    :param duration The duration for the display, default is 8 seconds.
+    :type duration int
+    """
+
+    iface.messageBar().pushMessage(title, message, QgsMessageBar.SUCCESS, duration)

--- a/safe/utilities/qgis_utilities.py
+++ b/safe/utilities/qgis_utilities.py
@@ -4,74 +4,188 @@ QGIS utilities for InaSAFE
 """
 
 __author__ = 'etienne'
+__revision__ = '$Format:%H$'
+__date__ = '17/02/2015'
+__copyright__ = 'Copyright 2012, Australia Indonesia Facility for '
+__copyright__ += 'Disaster Reduction'
 
 from qgis.gui import QgsMessageBar
 from qgis.utils import iface
+from PyQt4.QtGui import QMessageBox, QPushButton
+
+from safe.utilities.i18n import tr
 
 
-def display_information_message_bar(title=None, message=None, duration=8):
+def display_information_message_box(parent=None, title=None, message=None):
     """
-    Display a information message bar.
+    Display an information message box.
 
-    :param title The title of the message bar.
-    :type title str
+    :param title: The title of the message box.
+    :type title: str
 
-    :param message The message inside the message bar.
-    :type message str
-
-    :param duration The duration for the display, default is 8 seconds.
-    :type duration int
+    :param message: The message inside the message box.
+    :type message: str
     """
+    QMessageBox.information(parent, title, message)
 
-    iface.messageBar().pushMessage(title, message, QgsMessageBar.INFO, duration)
 
-
-def display_critical_message_bar(title=None, message=None, duration=8):
+def display_information_message_bar(
+        title=None, message=None, more_details=None, button_text=tr('Show details ...'), duration=8):
     """
-    Display a critical message bar.
+    Display an information message bar.
 
-    :param title The title of the message bar.
-    :type title str
+    :param title: The title of the message bar.
+    :type title: str
 
-    :param message The message inside the message bar.
-    :type message str
+    :param message: The message inside the message bar.
+    :type message: str
 
-    :param duration The duration for the display, default is 8 seconds.
-    :type duration int
-    """
+    :param more_details: The message inside the 'Show details' button.
+    :type more_details: str
 
-    iface.messageBar().pushMessage(title, message, QgsMessageBar.CRITICAL, duration)
+    :param button_text: The text of the button if 'more_details' is not empty.
+    :type button_text: str
 
-
-def display_warning_message_bar(title=None, message=None, duration=8):
-    """
-    Display a warning message bar.
-
-    :param title The title of the message bar.
-    :type title str
-
-    :param message The message inside the message bar.
-    :type message str
-
-    :param duration The duration for the display, default is 8 seconds.
-    :type duration int
+    :param duration: The duration for the display, default is 8 seconds.
+    :type duration: int
     """
 
-    iface.messageBar().pushMessage(title, message, QgsMessageBar.WARNING, duration)
+    widget = iface.messageBar().createMessage(title, message)
+
+    if more_details:
+        button = QPushButton(widget)
+        button.setText(button_text)
+        button.pressed.connect(
+            lambda: display_information_message_box(more_details)
+        )
+        widget.layout().addWidget(button)
+
+    iface.messageBar().pushWidget(widget, QgsMessageBar.INFO, duration)
 
 
-def display_success_message_bar(title=None, message=None, duration=8):
+def display_success_message_bar(
+        title=None, message=None, more_details=None, button_text=tr('Show details ...'), duration=8):
     """
     Display a success message bar.
 
-    :param title The title of the message bar.
-    :type title str
+    :param title: The title of the message bar.
+    :type title: str
 
-    :param message The message inside the message bar.
-    :type message str
+    :param message: The message inside the message bar.
+    :type message: str
 
-    :param duration The duration for the display, default is 8 seconds.
-    :type duration int
+    :param more_details: The message inside the 'Show details' button.
+    :type more_details: str
+
+    :param button_text: The text of the button if 'more_details' is not empty.
+    :type button_text: str
+
+    :param duration: The duration for the display, default is 8 seconds.
+    :type duration: int
     """
 
-    iface.messageBar().pushMessage(title, message, QgsMessageBar.SUCCESS, duration)
+    widget = iface.messageBar().createMessage(title, message)
+
+    if more_details:
+        button = QPushButton(widget)
+        button.setText(button_text)
+        button.pressed.connect(
+            lambda: display_information_message_box(title, more_details)
+        )
+        widget.layout().addWidget(button)
+
+    iface.messageBar().pushWidget(widget, QgsMessageBar.SUCCESS, duration)
+
+
+def display_warning_message_box(parent=None, title=None, message=None):
+    """
+    Display a warning message box.
+
+    :param title: The title of the message box.
+    :type title: str
+
+    :param message: The message inside the message box.
+    :type message: str
+    """
+    QMessageBox.warning(parent, title, message)
+
+
+def display_warning_message_bar(
+        title=None, message=None, more_details=None, button_text=tr('Show details ...'), duration=8):
+    """
+    Display a warning message bar.
+
+    :param title: The title of the message bar.
+    :type title: str
+
+    :param message: The message inside the message bar.
+    :type message: str
+
+    :param more_details: The message inside the 'Show details' button.
+    :type more_details: str
+
+    :param button_text: The text of the button if 'more_details' is not empty.
+    :type button_text: str
+
+    :param duration: The duration for the display, default is 8 seconds.
+    :type duration: int
+    """
+
+    widget = iface.messageBar().createMessage(title, message)
+
+    if more_details:
+        button = QPushButton(widget)
+        button.setText(button_text)
+        button.pressed.connect(
+            lambda: display_warning_message_box(title, more_details)
+        )
+        widget.layout().addWidget(button)
+
+    iface.messageBar().pushWidget(widget, QgsMessageBar.WARNING, duration)
+
+
+def display_critical_message_box(parent=None, title=None, message=None):
+    """
+    Display a critical message box.
+
+    :param title: The title of the message box.
+    :type title: str
+
+    :param message: The message inside the message box.
+    :type message: str
+    """
+    QMessageBox.critical(parent, title, message)
+
+
+def display_critical_message_bar(
+        title=None, message=None, more_details=None, button_text=tr('Show details ...'), duration=8):
+    """
+    Display a critical message bar.
+
+    :param title: The title of the message bar.
+    :type title: str
+
+    :param message: The message inside the message bar.
+    :type message: str
+
+    :param more_details: The message inside the 'Show details' button.
+    :type more_details: str
+
+    :param button_text: The text of the button if 'more_details' is not empty.
+    :type button_text: str
+
+    :param duration: The duration for the display, default is 8 seconds.
+    :type duration: int
+    """
+
+    widget = iface.messageBar().createMessage(title, message)
+
+    if more_details:
+        button = QPushButton(widget)
+        button.setText(button_text)
+        button.pressed.connect(
+            lambda: display_warning_message_box(title, more_details)
+        )
+        widget.layout().addWidget(button)
+
+    iface.messageBar().pushWidget(widget, QgsMessageBar.CRITICAL, duration)


### PR DESCRIPTION
fix #1423
When we use the "save as" function on a layer, .xml and .keywords are also saved

This branch rely on PR https://github.com/AIFDR/inasafe/pull/1652