### PR TITLE
fix #1225 : allow the user to select an area in the OSM downloader

### DIFF
--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -266,7 +266,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
             self, self.tr("Select download directory")))
 
     def drag_rectangle_on_map_canvas(self):
-        """ Show a dialog to choose directory. """
+        """ Hide the dialog and allow the user to draw a rectangle. """
 
         self.hide()
         self.rectangle_map_tool.reset()

--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -187,11 +187,11 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         show_context_help(self.help_context)
 
     def update_extent(self, extent):
-        """ Update extent value in GUI based from an extent.
+        """Update extent value in GUI based from an extent.
 
-        :param extent: a list in the form [xmin, ymin, xmax, ymax] where all
+        :param extent: A list in the form [xmin, ymin, xmax, ymax] where all
             coordinates provided are in Geographic / EPSG:4326.
-        :type: list
+        :type extent: list
         """
         self.min_longitude.setText(str(extent[0]))
         self.min_latitude.setText(str(extent[1]))
@@ -199,7 +199,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         self.max_latitude.setText(str(extent[3]))
 
     def update_extent_from_map_canvas(self):
-        """ Update extent value in GUI based from value in map.
+        """Update extent value in GUI based from value in map.
 
         .. note:: Delegates to update_extent()
         """
@@ -210,7 +210,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         self.update_extent(extent)
 
     def update_extent_from_rectangle(self):
-        """ Update extent value in GUI based from the QgsMapTool rectangle.
+        """Update extent value in GUI based from the QgsMapTool rectangle.
 
         .. note:: Delegates to update_extent()
         """
@@ -260,13 +260,13 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
 
     @pyqtSignature('')  # prevents actions being handled twice
     def on_directory_button_clicked(self):
-        """ Show a dialog to choose directory. """
+        """Show a dialog to choose directory."""
         # noinspection PyCallByClass,PyTypeChecker
         self.output_directory.setText(QFileDialog.getExistingDirectory(
             self, self.tr("Select download directory")))
 
     def drag_rectangle_on_map_canvas(self):
-        """ Hide the dialog and allow the user to draw a rectangle. """
+        """Hide the dialog and allow the user to draw a rectangle."""
 
         self.hide()
         self.rectangle_map_tool.reset()
@@ -480,7 +480,8 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         self.iface.addVectorLayer(path, feature_type, 'ogr')
 
     def reject(self):
-        """Redefinition of the reject() method to remove the rectangle selection tool.
+        """Redefinition of the reject() method
+        to remove the rectangle selection tool.
         It will call the super method.
         """
 

--- a/safe/gui/ui/osm_downloader_dialog_base.ui
+++ b/safe/gui/ui/osm_downloader_dialog_base.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>480</width>
+    <width>519</width>
     <height>594</height>
    </rect>
   </property>
@@ -91,6 +91,16 @@
      </property>
     </widget>
    </item>
+   <item row="8" column="0">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
    <item row="7" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="sizePolicy">
@@ -106,7 +116,7 @@
       <string>Bounding box</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>West</string>
@@ -116,19 +126,19 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="5" column="1">
        <widget class="QLineEdit" name="min_latitude"/>
       </item>
-      <item row="2" column="2">
+      <item row="4" column="2">
        <widget class="QLineEdit" name="max_longitude"/>
       </item>
-      <item row="1" column="1">
+      <item row="3" column="1">
        <widget class="QLineEdit" name="max_latitude"/>
       </item>
-      <item row="2" column="0">
+      <item row="4" column="0">
        <widget class="QLineEdit" name="min_longitude"/>
       </item>
-      <item row="0" column="1">
+      <item row="2" column="1">
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>North</string>
@@ -138,7 +148,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
+      <item row="3" column="2">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>East</string>
@@ -148,7 +158,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="6" column="1">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>South</string>
@@ -158,17 +168,14 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="button_extent_rectangle">
+        <property name="text">
+         <string>Draw a rectangle</string>
+        </property>
+       </widget>
+      </item>
      </layout>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
     </widget>
    </item>
   </layout>

--- a/safe/plugin.py
+++ b/safe/plugin.py
@@ -695,7 +695,7 @@ class Plugin(object):
         from safe.gui.tools.osm_downloader_dialog import OsmDownloaderDialog
 
         dialog = OsmDownloaderDialog(self.iface.mainWindow(), self.iface)
-        dialog.exec_()  # modal
+        dialog.show()  # non modal
 
     def show_batch_runner(self):
         """Show the batch runner dialog."""

--- a/safe/utilities/gis.py
+++ b/safe/utilities/gis.py
@@ -98,8 +98,11 @@ def extent_to_array(extent, source_crs, dest_crs=None):
     return geo_extent
 
 
-def viewport_geo_array(map_canvas):
-    """Obtain the map canvas current extent in EPSG:4326.
+def rectangle_geo_array(rectangle, map_canvas):
+    """Obtain the get_rectangle in EPSG:4326.
+
+    :param rectangle: A get_rectangle instance.
+    :type rectangle: QgsRectangle
 
     :param map_canvas: A map canvas instance.
     :type map_canvas: QgsMapCanvas
@@ -111,9 +114,6 @@ def viewport_geo_array(map_canvas):
     .. note:: Delegates to extent_to_array()
     """
 
-    # get the current viewport extent
-    rectangle = map_canvas.extent()
-
     destination_crs = QgsCoordinateReferenceSystem()
     destination_crs.createFromSrid(4326)
 
@@ -123,6 +123,25 @@ def viewport_geo_array(map_canvas):
         source_crs = destination_crs
 
     return extent_to_array(rectangle, source_crs, destination_crs)
+
+
+def viewport_geo_array(map_canvas):
+    """Obtain the map canvas current extent in EPSG:4326.
+
+    :param map_canvas: A map canvas instance.
+    :type map_canvas: QgsMapCanvas
+
+    :returns: A list in the form [xmin, ymin, xmax, ymax] where all
+        coordinates provided are in Geographic / EPSG:4326.
+    :rtype: list
+
+    .. note:: Delegates to rectangle_geo_array()
+    """
+
+    # get the current viewport extent
+    rectangle = map_canvas.extent()
+
+    return rectangle_geo_array(rectangle, map_canvas)
 
 
 def is_point_layer(layer):

--- a/safe/utilities/gis.py
+++ b/safe/utilities/gis.py
@@ -99,9 +99,9 @@ def extent_to_array(extent, source_crs, dest_crs=None):
 
 
 def rectangle_geo_array(rectangle, map_canvas):
-    """Obtain the get_rectangle in EPSG:4326.
+    """Obtain the rectangle in EPSG:4326.
 
-    :param rectangle: A get_rectangle instance.
+    :param rectangle: A rectangle instance.
     :type rectangle: QgsRectangle
 
     :param map_canvas: A map canvas instance.


### PR DESCRIPTION
This allows the user to select an area by drawing a rectangle, in the OSM downloader.
Until you start drawing a rectangle, the extent is set to the map canvas when the window is showed.
You can click on a button to hide the window and start drawing a rectangle. If the rectangle is valid, the extent is changed.