### PR TITLE
fix pep8 and fix #1730 : improvements on the OSM downloader

### DIFF
--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -492,7 +492,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
 
         if not os.path.exists(path):
             message = self.tr(
-                "%s doesn't exist. The server doesn't have any data on this "
+                "%s doesn't exist. The server doesn't have any data for this "
                 "extent." % path)
             raise ImportDialogError(message)
 

--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -133,9 +133,13 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         )
         tips = m.BulletedList()
         tips.add(self.tr(
-            'Your current extent will be used to determine the area for which '
-            'you want data to be retrieved. You can adjust it manually using '
-            'the bounding box options below.'))
+            'Your current extent, when opening this window, will be used to '
+            'determine the area for which you want data to be retrieved.'
+            'You can interactively select the area by using the '
+            '\'select on map\' button - which will temporarily hide this '
+            'window and allow you to drag a rectangle on the map. After you '
+            'have finished dragging the rectangle, this window will '
+            'reappear.'))
         tips.add(self.tr(
             'Check the output directory is correct. Note that the saved '
             'dataset will be called either roads.shp or buildings.shp (and '
@@ -488,7 +492,8 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
 
         if not os.path.exists(path):
             message = self.tr(
-                "%s don't exist. The server doesn't have any data.")
+                "%s doesn't exist. The server doesn't have any data on this "
+                "extent." % path)
             raise ImportDialogError(message)
 
         self.iface.addVectorLayer(path, feature_type, 'ogr')

--- a/safe/gui/tools/test/test_osm_downloader.py
+++ b/safe/gui/tools/test/test_osm_downloader.py
@@ -151,7 +151,8 @@ class FakeQNetworkAccessManager:
         elif url == ('http://osm.linfiniti.com/buildings-shp?'
                      'bbox=20.389938354492188,-34.10782492987083'
                      ',20.712661743164062,'
-                     '-34.008273470938335&qgis_version=2&output_prefix=&lang=en'):
+                     '-34.008273470938335&qgis_version=2&output_prefix='
+                     '&lang=en'):
             reply.content = read_all("test-importdlg-extractzip.zip")
 
         return reply

--- a/safe/gui/ui/extent_selector_dialog_base.ui
+++ b/safe/gui/ui/extent_selector_dialog_base.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>440</width>
+    <width>442</width>
     <height>389</height>
    </rect>
   </property>
@@ -19,23 +19,14 @@
    <string>InaSAFE Analysis Area</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../resources/resources.qrc">
+   <iconset>
     <normaloff>:/plugins/inasafe/icon.svg</normaloff>:/plugins/inasafe/icon.svg</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0">
-    <widget class="QWebView" name="web_view" native="true">
-     <property name="url" stdset="0">
-      <url>
-       <string>about:blank</string>
-      </url>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QGroupBox" name="group_box">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -50,61 +41,6 @@
       <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="y_maximum">
-        <property name="font">
-         <font>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="buttonSymbols">
-         <enum>QAbstractSpinBox::NoButtons</enum>
-        </property>
-        <property name="prefix">
-         <string>North: </string>
-        </property>
-        <property name="decimals">
-         <number>7</number>
-        </property>
-        <property name="minimum">
-         <double>-999999999.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>999999999.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QDoubleSpinBox" name="x_minimum">
-        <property name="font">
-         <font>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="buttonSymbols">
-         <enum>QAbstractSpinBox::NoButtons</enum>
-        </property>
-        <property name="prefix">
-         <string>East: </string>
-        </property>
-        <property name="decimals">
-         <number>7</number>
-        </property>
-        <property name="minimum">
-         <double>-999999999.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>999999999.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="capture_button">
-        <property name="text">
-         <string>Select on map</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="2">
        <widget class="QDoubleSpinBox" name="x_maximum">
         <property name="font">
@@ -153,10 +89,74 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QDoubleSpinBox" name="x_minimum">
+        <property name="font">
+         <font>
+          <pointsize>9</pointsize>
+         </font>
+        </property>
+        <property name="buttonSymbols">
+         <enum>QAbstractSpinBox::NoButtons</enum>
+        </property>
+        <property name="prefix">
+         <string>East: </string>
+        </property>
+        <property name="decimals">
+         <number>7</number>
+        </property>
+        <property name="minimum">
+         <double>-999999999.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="capture_button">
+        <property name="text">
+         <string>Select on map</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QDoubleSpinBox" name="y_maximum">
+        <property name="font">
+         <font>
+          <pointsize>9</pointsize>
+         </font>
+        </property>
+        <property name="buttonSymbols">
+         <enum>QAbstractSpinBox::NoButtons</enum>
+        </property>
+        <property name="prefix">
+         <string>North: </string>
+        </property>
+        <property name="decimals">
+         <number>7</number>
+        </property>
+        <property name="minimum">
+         <double>-999999999.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="0" column="0">
+    <widget class="QWebView" name="web_view" native="true">
+     <property name="url" stdset="0">
+      <url>
+       <string>about:blank</string>
+      </url>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>

--- a/safe/gui/ui/osm_downloader_dialog_base.ui
+++ b/safe/gui/ui/osm_downloader_dialog_base.ui
@@ -109,7 +109,7 @@
    <item row="7" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -173,10 +173,10 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="4" column="1">
        <widget class="QPushButton" name="button_extent_rectangle">
         <property name="text">
-         <string>Draw a rectangle</string>
+         <string>Select on map</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
fix pep8 and fix #1730 : improvements on the OSM downloader : 
  - fix horizontal layout on the OSM downloader
  - fix horizontal layout on the extent selector dialog
  - fix error message when no OSM data
  - move the button down about "select on map"