### PR TITLE
fix #1732 : OSM downloader : skip a feature type if one is empty

### DIFF
--- a/safe/common/exceptions.py
+++ b/safe/common/exceptions.py
@@ -259,6 +259,11 @@ class ImportDialogError(Exception):
     pass
 
 
+class FileMissingError(Exception):
+    """Raised if a file cannot be found."""
+    pass
+
+
 class CanceledImportDialogError(Exception):
     """Raised if import process canceled"""
     pass

--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -38,7 +38,10 @@ from PyQt4.QtGui import (
 from PyQt4.QtNetwork import QNetworkAccessManager
 
 from safe.common.exceptions import (
-    CanceledImportDialogError, ImportDialogError, DownloadError)
+    CanceledImportDialogError,
+    ImportDialogError,
+    DownloadError,
+    FileMissingError)
 from safe import messaging as m
 from safe.utilities.file_downloader import FileDownloader
 from safe.utilities.gis import viewport_geo_array, rectangle_geo_array
@@ -46,6 +49,7 @@ from safe.utilities.resources import html_footer, html_header, get_ui_class
 from safe.utilities.help import show_context_help
 from safe.messaging import styles
 from safe.utilities.proxy import get_proxy
+from safe.utilities.qgis_utilities import display_warning_message_box
 from safe.gui.tools.rectangle_map_tool import RectangleMapTool
 
 INFO_STYLE = styles.INFO_STYLE
@@ -311,7 +315,13 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
             self.require_directory()
             for feature_type in feature_types:
                 self.download(feature_type)
-                self.load_shapefile(feature_type)
+                try:
+                    self.load_shapefile(feature_type)
+                except FileMissingError as exception:
+                    display_warning_message_box(
+                        self,
+                        error_dialog_title,
+                        str(exception))
             self.done(QDialog.Accepted)
             self.rectangle_map_tool.reset()
 
@@ -489,7 +499,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         if not os.path.exists(path):
             message = self.tr(
                 "%s don't exist. The server doesn't have any data.")
-            raise ImportDialogError(message)
+            raise FileMissingError(message)
 
         self.iface.addVectorLayer(path, feature_type, 'ogr')
 


### PR DESCRIPTION
fix #1732 : OSM downloader : skip a feature type if one is empty