### PR TITLE
fix #1739 exception about canceled download

### DIFF
--- a/safe/utilities/file_downloader.py
+++ b/safe/utilities/file_downloader.py
@@ -115,7 +115,7 @@ class FileDownloader(object):
         if result == QNetworkReply.NoError:
             return True, None
         else:
-            return result, str(self.reply.errorString())
+            return result, self.reply.errorString()
 
     def get_buffer(self):
         """Get buffer from self.reply and store it to our buffer container."""


### PR DESCRIPTION
An ``CanceledImportDialogError`` is raised instead of ``DownloadError`` when a download is canceled.