### PR TITLE
fix #1679 : change how the zip is extracted, allow the user to overwrite or not

### DIFF
--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -318,9 +318,16 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
             self.save_state()
             self.require_directory()
             for feature_type in feature_types:
-                self.download(feature_type)
+
+                output_directory = self.output_directory.text()
+                output_prefix = self.filename_prefix.text()
+                overwrite = self.overwrite_checkBox.isChecked()
+                output_base_file_path = self.get_output_base_path(
+                    output_directory, output_prefix, feature_type, overwrite)
+
+                self.download(feature_type, output_base_file_path)
                 try:
-                    self.load_shapefile(feature_type)
+                    self.load_shapefile(feature_type, output_base_file_path)
                 except FileMissingError as exception:
                     display_warning_message_box(
                         self,
@@ -343,6 +350,79 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         finally:
             # Unlock the groupbox
             self.groupBox.setEnabled(True)
+
+    def get_output_base_path(
+            self,
+            output_directory,
+            output_prefix,
+            feature_type,
+            overwrite):
+        """Get a full base name path to save the shapefile.
+
+        :param output_directory: The directory where to put results.
+        :type output_directory: str
+
+        :param output_prefix: The prefix to add for the shapefile.
+        :type output_prefix: str
+
+        :param feature_type: What kind of features should be downloaded.
+            Currently 'buildings', 'building-points' or 'roads' are supported.
+        :type feature_type: str
+
+        :param overwrite: Boolean to know if we can overwrite existing files.
+        :type overwrite: str
+
+        :return: The base path.
+        :rtype: str
+        """
+        path = os.path.join(
+            output_directory, '%s%s' % (output_prefix, feature_type))
+
+        if not overwrite:
+            separator = '-'
+            suffix = self.get_unique_suffix_file_path(
+                '%s.shp' % path, separator)
+
+            if suffix:
+                path = os.path.join(output_directory, '%s%s%s%s' % (
+                    output_prefix, feature_type, separator, suffix))
+
+        return path
+
+    @staticmethod
+    def get_unique_suffix_file_path(file_path, separator='-', i=0):
+        """Check and return the minimum number to suffix the file with a
+        separator and an integer to prevent overwriting a file with the same
+        name.
+        Example : /tmp/a.txt exists.
+            - With file_path='/tmp/b.txt' will return 0.
+            - With file_path='/tmp/a.txt' will return 1 (/tmp/a-1.txt)
+
+        :param file_path: The file to check.
+        :type file_path: str
+
+        :param separator: The separator to test.
+        :type separator: str
+
+        :param i: The minimum suffix to check.
+        :type i: int
+
+        :return: The minimum prefix you should add to not overwrite a file.
+        :rtype: int
+        """
+
+        basename = os.path.splitext(file_path)
+        if i != 0:
+            file_path_test = os.path.join(
+                '%s%s%s%s' % (basename[0], separator, i, basename[1]))
+        else:
+            file_path_test = file_path
+
+        if os.path.isfile(file_path_test):
+            return OsmDownloaderDialog.get_unique_suffix_file_path(
+                file_path, separator, i + 1)
+        else:
+            return i
 
     def require_directory(self):
         """Ensure directory path entered in dialog exist.
@@ -378,12 +458,15 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         else:
             raise CanceledImportDialogError()
 
-    def download(self, feature_type):
+    def download(self, feature_type, output_base_path):
         """Download shapefiles from Linfiniti server.
 
         :param feature_type: What kind of features should be downloaded.
             Currently 'buildings', 'building-points' or 'roads' are supported.
         :type feature_type: str
+
+        :param output_base_path: The base path of the shape file.
+        :type output_base_path: str
 
         :raises: ImportDialogError, CanceledImportDialogError
         """
@@ -402,7 +485,6 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
                 max_longitude=max_longitude,
                 max_latitude=max_latitude
             )
-        output_prefix = self.filename_prefix.text()
         if feature_type == 'buildings':
             url = "{url}?bbox={box}&qgis_version=2".format(
                 url=self.buildings_url, box=box)
@@ -413,9 +495,6 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
             url = "{url}?bbox={box}&qgis_version=2".format(
                 url=self.roads_url, box=box)
 
-        if output_prefix is not None:
-            url += '&output_prefix=%s' % output_prefix
-
         if 'LANG' in os.environ:
             env_lang = os.environ['LANG']
             url += '&lang=%s' % env_lang
@@ -424,7 +503,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
 
         # download and extract it
         self.fetch_zip(url, path, feature_type)
-        self.extract_zip(path, self.output_directory.text())
+        self.extract_zip(path, output_base_path)
 
         self.progress_dialog.done(QDialog.Accepted)
 
@@ -477,14 +556,25 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
                 raise DownloadError(error_message)
 
     @staticmethod
-    def extract_zip(path, output_dir):
-        """Extract all content of a .zip file from path to output_dir.
+    def extract_zip(zip_path, destination_base_path):
+        """Extract different extensions to the destination base path.
 
-        :param path: The path of the .zip file
-        :type path: str
+        Example : test.zip contains a.shp, a.dbf, a.prj
+        and destination_base_path = '/tmp/CT-buildings
+        Expected result :
+            - /tmp/CT-buildings.shp
+            - /tmp/CT-buildings.dbf
+            - /tmp/CT-buildings.prj
 
-        :param output_dir: Output directory where the shp will be written to.
-        :type output_dir: str
+        If two files in the zip with the same extension, only the last one will
+        be copied.
+
+        :param zip_path: The path of the .zip file
+        :type zip_path: str
+
+        :param destination_base_path: The destination base path where the shp
+        will be written to.
+        :type destination_base_path: str
 
         :raises: IOError - when not able to open path or output_dir does not
             exist.
@@ -492,29 +582,31 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
 
         import zipfile
 
-        # extract all files...
-        handle = open(path, 'rb')
+        handle = open(zip_path, 'rb')
         zip_file = zipfile.ZipFile(handle)
         for name in zip_file.namelist():
-            output_path = os.path.join(output_dir, name)
-            output_file = open(output_path, 'wb')
+            extension = os.path.splitext(name)[1]
+            output_final_path = u'%s%s' % (destination_base_path, extension)
+            output_file = open(output_final_path, 'wb')
             output_file.write(zip_file.read(name))
             output_file.close()
 
         handle.close()
 
-    def load_shapefile(self, feature_type):
+    def load_shapefile(self, feature_type, base_path):
         """Load downloaded shape file to QGIS Main Window.
 
         :param feature_type: What kind of features should be downloaded.
             Currently 'buildings', 'building-points' or 'roads' are supported.
         :type feature_type: str
 
+        :param base_path: The base path of the shape file (without extension).
+        :type base_path: str
+
         :raises: ImportDialogError - when buildings.shp not exist
         """
-        output_prefix = self.filename_prefix.text()
-        path = self.output_directory.text()
-        path = os.path.join(path, '%s%s.shp' % (output_prefix, feature_type))
+
+        path = '%s.shp' % base_path
 
         if not os.path.exists(path):
             message = self.tr(

--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -370,7 +370,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         :type feature_type: str
 
         :param overwrite: Boolean to know if we can overwrite existing files.
-        :type overwrite: str
+        :type overwrite: bool
 
         :return: The base path.
         :rtype: str
@@ -380,7 +380,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
 
         if not overwrite:
             separator = '-'
-            suffix = self.get_unique_suffix_file_path(
+            suffix = self.get_unique_file_path_suffix(
                 '%s.shp' % path, separator)
 
             if suffix:
@@ -390,10 +390,8 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         return path
 
     @staticmethod
-    def get_unique_suffix_file_path(file_path, separator='-', i=0):
-        """Check and return the minimum number to suffix the file with a
-        separator and an integer to prevent overwriting a file with the same
-        name.
+    def get_unique_file_path_suffix(file_path, separator='-', i=0):
+        """Return the minimum number to suffix the file to not overwrite one.
         Example : /tmp/a.txt exists.
             - With file_path='/tmp/b.txt' will return 0.
             - With file_path='/tmp/a.txt' will return 1 (/tmp/a-1.txt)
@@ -419,7 +417,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
             file_path_test = file_path
 
         if os.path.isfile(file_path_test):
-            return OsmDownloaderDialog.get_unique_suffix_file_path(
+            return OsmDownloaderDialog.get_unique_file_path_suffix(
                 file_path, separator, i + 1)
         else:
             return i
@@ -459,7 +457,7 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
             raise CanceledImportDialogError()
 
     def download(self, feature_type, output_base_path):
-        """Download shapefiles from Linfiniti server.
+        """Download shapefiles from Kartoza server.
 
         :param feature_type: What kind of features should be downloaded.
             Currently 'buildings', 'building-points' or 'roads' are supported.
@@ -566,14 +564,14 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
             - /tmp/CT-buildings.dbf
             - /tmp/CT-buildings.prj
 
-        If two files in the zip with the same extension, only the last one will
-        be copied.
+        If two files in the zip with the same extension, only one will be
+        copied.
 
         :param zip_path: The path of the .zip file
         :type zip_path: str
 
         :param destination_base_path: The destination base path where the shp
-        will be written to.
+            will be written to.
         :type destination_base_path: str
 
         :raises: IOError - when not able to open path or output_dir does not

--- a/safe/gui/tools/test/test_osm_downloader.py
+++ b/safe/gui/tools/test/test_osm_downloader.py
@@ -269,25 +269,24 @@ class ImportDialogTest(unittest.TestCase):
 
         message = "Index for existing files is wrong."
 
-        result = self.dialog.get_unique_suffix_file_path(one_file)
+        result = self.dialog.get_unique_file_path_suffix(one_file)
         assert result == 2, message
 
         os.remove(other_file)
-        result = self.dialog.get_unique_suffix_file_path(one_file)
+        result = self.dialog.get_unique_file_path_suffix(one_file)
         assert result == 1, message
 
         os.remove(one_file)
-        result = self.dialog.get_unique_suffix_file_path(one_file)
+        result = self.dialog.get_unique_file_path_suffix(one_file)
         assert result == 0, message
 
         # cleanup
         shutil.rmtree(path)
 
     def test_extract_zip(self):
-        """Test extract_zip method.
-        The extract_zip method will only take care of one file for each
-        extensions. If many files has the same extension, only the last one
-        will be copied.
+        """Test extract_zip method which will only take care of one file for
+        each extensions. If many files has the same extension, only the last
+        one will be copied.
         """
         base_path = tempfile.mkdtemp()
         base_file_path = os.path.join(base_path, 'test')

--- a/safe/gui/ui/osm_downloader_dialog_base.ui
+++ b/safe/gui/ui/osm_downloader_dialog_base.ui
@@ -14,50 +14,10 @@
    <string>OSM Downloader</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0">
-    <widget class="QWebView" name="web_view" native="true">
-     <property name="url" stdset="0">
-      <url>
-       <string>about:blank</string>
-      </url>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="feature_type_label">
      <property name="text">
       <string>Feature Type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QComboBox" name="feature_type">
-     <item>
-      <property name="text">
-       <string>All</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Buildings</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Building points</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Roads</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="output_directory_label">
-     <property name="text">
-      <string>Output directory</string>
      </property>
     </widget>
    </item>
@@ -86,6 +46,37 @@
      </property>
     </widget>
    </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="output_directory_label">
+     <property name="text">
+      <string>Output directory</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QComboBox" name="feature_type">
+     <item>
+      <property name="text">
+       <string>All</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Buildings</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Building points</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Roads</string>
+      </property>
+     </item>
+    </widget>
+   </item>
    <item row="6" column="0">
     <widget class="QLineEdit" name="filename_prefix">
      <property name="inputMask">
@@ -97,16 +88,6 @@
     </widget>
    </item>
    <item row="8" column="0">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
@@ -181,6 +162,32 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QWebView" name="web_view" native="true">
+     <property name="url" stdset="0">
+      <url>
+       <string>about:blank</string>
+      </url>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QCheckBox" name="overwrite_checkBox">
+     <property name="text">
+      <string>Overwrite if existing files</string>
+     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Add an option to overwrite or not existing files when using the OSM downloader.
The &output_prefix is not uploaded to the server any more because when extracting the zip, the process will generate a safe base path where to extract files.

![sa1](https://cloud.githubusercontent.com/assets/1609292/6619483/242b270c-c8d3-11e4-9f74-d387d1719dcb.jpg)
