### PR TITLE
fix #1764 : allow a user to select the area with a bookmark

### DIFF
--- a/safe/gui/tools/extent_selector_dialog.py
+++ b/safe/gui/tools/extent_selector_dialog.py
@@ -319,12 +319,13 @@ class ExtentSelectorDialog(QDialog, FORM_CLASS):
         db = sqlite3.connect(db_file_path)
         cursor = db.cursor()
         cursor.execute(
-            'SELECT name '
+            'SELECT COUNT(*) '
             'FROM sqlite_master '
             'WHERE type=\'table\' '
             'AND name=\'tbl_bookmarks\';')
 
-        if cursor.rowcount != 0:
+        number_of_rows = cursor.fetchone()[0]
+        if number_of_rows > 0:
             cursor.execute(
                 'SELECT * '
                 'FROM tbl_bookmarks;')

--- a/safe/gui/tools/extent_selector_dialog.py
+++ b/safe/gui/tools/extent_selector_dialog.py
@@ -158,6 +158,7 @@ class ExtentSelectorDialog(QDialog, FORM_CLASS):
             'on map\' button - which will temporarily hide this window and '
             'allow you to drag a rectangle on the map. After you have '
             'finished dragging the rectangle, this window will reappear. '
+            'You can also use one of your bookmarks to set the region. '
             'If you enable the \'Toggle scenario outlines\' tool on the '
             'InaSAFE toolbar, your user defined extent will be shown on '
             'the map as a blue rectangle. Please note that when running '
@@ -283,7 +284,7 @@ class ExtentSelectorDialog(QDialog, FORM_CLASS):
         self.blockSignals(False)
 
     def bookmarks_index_changed(self):
-        """Update the UI when the combobox about bookmarks has changed.
+        """Update the UI when the bookmarks combobox has changed.
         """
         index = self.comboBox_bookmarks_list.currentIndex()
         if index >= 0:
@@ -296,9 +297,9 @@ class ExtentSelectorDialog(QDialog, FORM_CLASS):
             self.ok_button.setDisabled(True)
 
     def on_checkBox_use_bookmark_toggled(self, use_bookmark):
-        """Update the UI when the user toggles the checkbox about bookmarks.
+        """Update the UI when the user toggles the bookmarks checkbox.
 
-        :param use_bookmark: The status of the checkbox
+        :param use_bookmark: The status of the checkbox.
         :type use_bookmark: bool
         """
         if use_bookmark:
@@ -311,6 +312,7 @@ class ExtentSelectorDialog(QDialog, FORM_CLASS):
 
     def _populate_bookmarks_list(self):
         """Read the sqlite database and populate the bookmarks list.
+
         Every bookmark are reprojected to mapcanvas crs.
         """
 

--- a/safe/gui/tools/extent_selector_dialog.py
+++ b/safe/gui/tools/extent_selector_dialog.py
@@ -24,6 +24,7 @@ __copyright__ = '(C) 2010, Giuseppe Sucameli'
 __revision__ = '$Format:%H$'
 
 import logging
+import sqlite3
 
 # noinspection PyUnresolvedReferences
 # pylint: disable=unused-import
@@ -39,6 +40,7 @@ from qgis.core import (
     QgsPoint,
     QgsRectangle,
     QgsCoordinateReferenceSystem,
+    QgsApplication,
     QgsCoordinateTransform)
 
 from safe import messaging as m
@@ -118,8 +120,8 @@ class ExtentSelectorDialog(QDialog, FORM_CLASS):
         # Make sure to reshow this dialog when rectangle is captured
         self.tool.rectangle_created.connect(self.stop_capture)
         # Setup ok button
-        ok_button = self.button_box.button(QtGui.QDialogButtonBox.Ok)
-        ok_button.clicked.connect(self.accept)
+        self.ok_button = self.button_box.button(QtGui.QDialogButtonBox.Ok)
+        self.ok_button.clicked.connect(self.accept)
         # Set up context help
         self.help_context = 'user_extents'
         help_button = self.button_box.button(QtGui.QDialogButtonBox.Help)
@@ -128,6 +130,11 @@ class ExtentSelectorDialog(QDialog, FORM_CLASS):
         clear_button = self.button_box.button(QtGui.QDialogButtonBox.Reset)
         clear_button.setText(self.tr('Clear'))
         clear_button.clicked.connect(self.clear)
+
+        # Populate the bookmarks list and connect the combobox
+        self._populate_bookmarks_list()
+        self.comboBox_bookmarks_list.currentIndexChanged.connect(
+            self.bookmarks_index_changed)
 
     def show_help(self):
         """Load the help text for the dialog."""
@@ -274,3 +281,69 @@ class ExtentSelectorDialog(QDialog, FORM_CLASS):
             self.x_maximum.clear()
             self.y_maximum.clear()
         self.blockSignals(False)
+
+    def bookmarks_index_changed(self):
+        """Update the UI when the combobox about bookmarks has changed.
+        """
+        index = self.comboBox_bookmarks_list.currentIndex()
+        if index >= 0:
+            self.tool.reset()
+            rectangle = self.comboBox_bookmarks_list.itemData(index)
+            self.tool.set_rectangle(rectangle)
+            self.canvas.setExtent(rectangle)
+            self.ok_button.setEnabled(True)
+        else:
+            self.ok_button.setDisabled(True)
+
+    def on_checkBox_use_bookmark_toggled(self, use_bookmark):
+        """Update the UI when the user toggles the checkbox about bookmarks.
+
+        :param use_bookmark: The status of the checkbox
+        :type use_bookmark: bool
+        """
+        if use_bookmark:
+            self.bookmarks_index_changed()
+            self.groupBox_coordinates.setDisabled(True)
+        else:
+            self.groupBox_coordinates.setEnabled(True)
+            self.ok_button.setEnabled(True)
+        self._populate_coordinates()
+
+    def _populate_bookmarks_list(self):
+        """Read the sqlite database and populate the bookmarks list.
+        Every bookmark are reprojected to mapcanvas crs.
+        """
+
+        # Connect to the QGIS sqlite database and check if the table exists.
+        db_file_path = QgsApplication.qgisUserDbFilePath()
+        db = sqlite3.connect(db_file_path)
+        cursor = db.cursor()
+        cursor.execute(
+            'SELECT name '
+            'FROM sqlite_master '
+            'WHERE type=\'table\' '
+            'AND name=\'tbl_bookmarks\';')
+
+        if cursor.rowcount != 0:
+            cursor.execute(
+                'SELECT * '
+                'FROM tbl_bookmarks;')
+            bookmarks = cursor.fetchall()
+
+            canvas_srid = self.canvas.mapRenderer().destinationCrs().srsid()
+
+            for bookmark in bookmarks:
+                name = bookmark[1]
+                srid = bookmark[7]
+                rectangle = QgsRectangle(
+                    bookmark[3], bookmark[4], bookmark[5], bookmark[6])
+
+                if srid != canvas_srid:
+                    transform = QgsCoordinateTransform(
+                        srid, canvas_srid)
+                    rectangle = transform.transform(rectangle)
+
+                if rectangle.isEmpty():
+                    pass
+
+                self.comboBox_bookmarks_list.addItem(name, rectangle)

--- a/safe/gui/ui/extent_selector_dialog_base.ui
+++ b/safe/gui/ui/extent_selector_dialog_base.ui
@@ -40,108 +40,144 @@
      <property name="flat">
       <bool>true</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="2">
-       <widget class="QDoubleSpinBox" name="x_maximum">
-        <property name="font">
-         <font>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="buttonSymbols">
-         <enum>QAbstractSpinBox::NoButtons</enum>
-        </property>
-        <property name="prefix">
-         <string>West: </string>
-        </property>
-        <property name="decimals">
-         <number>7</number>
-        </property>
-        <property name="minimum">
-         <double>-999999999.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>999999999.000000000000000</double>
-        </property>
-       </widget>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QCheckBox" name="checkBox_use_bookmark">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Use a bookmark</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="comboBox_bookmarks_list">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="2" column="1">
-       <widget class="QDoubleSpinBox" name="y_minimum">
-        <property name="font">
-         <font>
-          <pointsize>9</pointsize>
-         </font>
+      <item>
+       <widget class="QGroupBox" name="groupBox_coordinates">
+        <property name="title">
+         <string/>
         </property>
-        <property name="buttonSymbols">
-         <enum>QAbstractSpinBox::NoButtons</enum>
+        <property name="flat">
+         <bool>true</bool>
         </property>
-        <property name="prefix">
-         <string>South: </string>
-        </property>
-        <property name="decimals">
-         <number>7</number>
-        </property>
-        <property name="minimum">
-         <double>-999999999.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>999999999.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QDoubleSpinBox" name="x_minimum">
-        <property name="font">
-         <font>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="buttonSymbols">
-         <enum>QAbstractSpinBox::NoButtons</enum>
-        </property>
-        <property name="prefix">
-         <string>East: </string>
-        </property>
-        <property name="decimals">
-         <number>7</number>
-        </property>
-        <property name="minimum">
-         <double>-999999999.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>999999999.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="capture_button">
-        <property name="text">
-         <string>Select on map</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="y_maximum">
-        <property name="font">
-         <font>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="buttonSymbols">
-         <enum>QAbstractSpinBox::NoButtons</enum>
-        </property>
-        <property name="prefix">
-         <string>North: </string>
-        </property>
-        <property name="decimals">
-         <number>7</number>
-        </property>
-        <property name="minimum">
-         <double>-999999999.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>999999999.000000000000000</double>
-        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="1" column="1">
+          <widget class="QPushButton" name="capture_button">
+           <property name="text">
+            <string>Select on map</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QDoubleSpinBox" name="y_maximum">
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+            </font>
+           </property>
+           <property name="buttonSymbols">
+            <enum>QAbstractSpinBox::NoButtons</enum>
+           </property>
+           <property name="prefix">
+            <string>North: </string>
+           </property>
+           <property name="decimals">
+            <number>7</number>
+           </property>
+           <property name="minimum">
+            <double>-999999999.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>999999999.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QDoubleSpinBox" name="x_minimum">
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+            </font>
+           </property>
+           <property name="buttonSymbols">
+            <enum>QAbstractSpinBox::NoButtons</enum>
+           </property>
+           <property name="prefix">
+            <string>East: </string>
+           </property>
+           <property name="decimals">
+            <number>7</number>
+           </property>
+           <property name="minimum">
+            <double>-999999999.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>999999999.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QDoubleSpinBox" name="x_maximum">
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+            </font>
+           </property>
+           <property name="buttonSymbols">
+            <enum>QAbstractSpinBox::NoButtons</enum>
+           </property>
+           <property name="prefix">
+            <string>West: </string>
+           </property>
+           <property name="decimals">
+            <number>7</number>
+           </property>
+           <property name="minimum">
+            <double>-999999999.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>999999999.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QDoubleSpinBox" name="y_minimum">
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+            </font>
+           </property>
+           <property name="buttonSymbols">
+            <enum>QAbstractSpinBox::NoButtons</enum>
+           </property>
+           <property name="prefix">
+            <string>South: </string>
+           </property>
+           <property name="decimals">
+            <number>7</number>
+           </property>
+           <property name="minimum">
+            <double>-999999999.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>999999999.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
@@ -173,15 +209,27 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>x_minimum</tabstop>
-  <tabstop>y_maximum</tabstop>
-  <tabstop>x_maximum</tabstop>
-  <tabstop>y_minimum</tabstop>
-  <tabstop>capture_button</tabstop>
   <tabstop>button_box</tabstop>
  </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>
- <connections/>
+ <connections>
+  <connection>
+   <sender>checkBox_use_bookmark</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>comboBox_bookmarks_list</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>68</x>
+     <y>239</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>279</x>
+     <y>238</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
This PR adds a new option to set the analysis area, see https://github.com/AIFDR/inasafe/issues/1764.
The user can select one of his bookmark by clicking on the checkbox.

![bookmark](https://cloud.githubusercontent.com/assets/1609292/6820986/911ef8bc-d2dc-11e4-9cb9-3e734e000390.jpg)