### PR TITLE
fix #1770 check if the map canvas is using 4326 and enable OTF if necessary

### DIFF
--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -49,7 +49,9 @@ from safe.utilities.resources import html_footer, html_header, get_ui_class
 from safe.utilities.help import show_context_help
 from safe.messaging import styles
 from safe.utilities.proxy import get_proxy
-from safe.utilities.qgis_utilities import display_warning_message_box
+from safe.utilities.qgis_utilities import (
+    display_warning_message_box,
+    display_warning_message_bar)
 from safe.gui.tools.rectangle_map_tool import RectangleMapTool
 
 INFO_STYLE = styles.INFO_STYLE
@@ -622,6 +624,20 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
             raise FileMissingError(message)
 
         self.iface.addVectorLayer(path, feature_type, 'ogr')
+
+        canvas_srid = self.canvas.mapRenderer().destinationCrs().srsid()
+        on_the_fly_projection = self.canvas.hasCrsTransformEnabled()
+        if canvas_srid != 4326 and not on_the_fly_projection:
+            if QGis.QGIS_VERSION_INT >= 20400:
+                self.canvas.setCrsTransformEnabled(True)
+            else:
+                display_warning_message_bar(
+                    self.tr('Enable \'on the fly\''),
+                    self.tr(
+                        'Your current projection is different than EPSG:4326. '
+                        'You should enable \'on the fly\' to display '
+                        'correctly your layers')
+                    )
 
     def reject(self):
         """Redefinition of the reject() method

--- a/safe/utilities/gis.py
+++ b/safe/utilities/gis.py
@@ -117,10 +117,7 @@ def rectangle_geo_array(rectangle, map_canvas):
     destination_crs = QgsCoordinateReferenceSystem()
     destination_crs.createFromSrid(4326)
 
-    if map_canvas.hasCrsTransformEnabled():
-        source_crs = map_canvas.mapRenderer().destinationCrs()
-    else:
-        source_crs = destination_crs
+    source_crs = map_canvas.mapRenderer().destinationCrs()
 
     return extent_to_array(rectangle, source_crs, destination_crs)
 


### PR DESCRIPTION
fix #1770 check if the map canvas is using 4326 and enable OTF if necessary