### PR TITLE
Remove 'disable_for_entire_area_aggregation_param' postprocessor paramet...

### DIFF
--- a/safe/defaults.py
+++ b/safe/defaults.py
@@ -185,18 +185,14 @@ def age_postprocessor():
 def aggregation_categorical_postprocessor():
     """Get aggregation categorical postprocessor selectors.
 
-    :return: A list of Parameters.
+    :return: List of boolean parameter.
     :rtype: list
     """
-    aggregatec = BooleanParameter()
-    aggregatec.name = 'Aggregation categorical'
-    aggregatec.value = True
+    aggregation_categorical = BooleanParameter()
+    aggregation_categorical.name = 'Aggregation categorical'
+    aggregation_categorical.value = True
 
-    disable_area_aggregation = BooleanParameter()
-    disable_area_aggregation.name = 'disable_for_entire_area_aggregation'
-    disable_area_aggregation.value = False
-
-    return [aggregatec, disable_area_aggregation]
+    return [aggregation_categorical]
 
 
 def road_type_postprocessor():

--- a/safe/impact_statistics/postprocessor_manager.py
+++ b/safe/impact_statistics/postprocessor_manager.py
@@ -275,8 +275,7 @@ class PostprocessorManager(QtCore.QObject):
         try:
             requested_postprocessors = self.function_parameters[
                 'postprocessors']
-            postprocessors = get_postprocessors(
-                requested_postprocessors, self.aggregator.aoi_mode)
+            postprocessors = get_postprocessors(requested_postprocessors)
         except (TypeError, KeyError):
             # TypeError is for when function_parameters is none
             # KeyError is for when ['postprocessors'] is unavailable

--- a/safe/postprocessors/postprocessor_factory.py
+++ b/safe/postprocessors/postprocessor_factory.py
@@ -38,12 +38,11 @@ AVAILABLE_POSTPTOCESSORS = {
     'Aggregation': 'Aggregation',
     'BuildingType': 'Building type',
     'RoadType': 'Road type',
-    'AggregationCategorical':
-    'Aggregation categorical',
+    'AggregationCategorical': 'Aggregation categorical',
     'MinimumNeeds': 'Minimum needs'}
 
 
-def get_postprocessors(requested_postprocessors, aoi_mode):
+def get_postprocessors(requested_postprocessors):
     """
     Creates a dictionary of applicable postprocessor instances
 
@@ -61,10 +60,6 @@ def get_postprocessors(requested_postprocessors, aoi_mode):
             skip it returning the valid ones
     :type requested_postprocessors: dict e.g. name:[list_elements]
 
-    :param aoi_mode: Whether postprocessing is being done on current analysis
-        extents or on an aggregation layer.
-    :type aoi_mode: bool
-
     :returns: Dict of postprocessors instances e.g.::
 
             {'Gender': GenderPostprocessors instance}
@@ -77,28 +72,24 @@ def get_postprocessors(requested_postprocessors, aoi_mode):
     if requested_postprocessors is None or requested_postprocessors == {}:
         return postprocessor_instances
     for name, values in requested_postprocessors.iteritems():
-        constr_id = name + 'Postprocessor'
-        # Flag specifying if aggregation is required. If set, postprocessor
-        # will be disabled when AOI mode is enabled.
-        requires_aggregation = True
-        # lets check if the IF has a
-        # ['params']['disable_for_entire_area_aggregation']
-        # that would turn off the current postprocessor if in aoi_mode
+        constructor_class_name = name + 'Postprocessor'
         try:
-            if values[0].value and requires_aggregation:
+            if values[0].value:
                 if name in AVAILABLE_POSTPTOCESSORS.keys():
                     # http://stackoverflow.com/a/554462
-                    constr = globals()[constr_id]
-                    instance = constr()
+                    constructor = globals()[constructor_class_name]
+                    instance = constructor()
                     postprocessor_instances[name] = instance
                 else:
-                    LOGGER.debug(constr_id + ' is not a valid Postprocessor,'
-                                             ' skipping it')
-
+                    LOGGER.debug(
+                        constructor_class_name + ' is not a valid '
+                                                 'Postprocessor, skipping it')
             else:
-                LOGGER.debug(constr_id + ' user disabled, skipping it')
+                LOGGER.debug(
+                    constructor_class_name + ' user disabled, skipping it')
         except KeyError:
-            LOGGER.debug(constr_id + ' has no "on" key, skipping it')
+            LOGGER.debug(
+                constructor_class_name + ' has no "on" key, skipping it')
 
     return postprocessor_instances
 

--- a/safe/utilities/analysis.py
+++ b/safe/utilities/analysis.py
@@ -652,11 +652,7 @@ class Analysis(object):
             # add which postprocessors will run when appropriated
             post_processors_names = self.impact_function.parameters[
                 'postprocessors']
-            # aggregator is not ready yet here so we can't use
-            # self.aggregator.aoi_mode
-            aoi_mode = self.aggregation_layer is None
-            post_processors = get_postprocessors(
-                post_processors_names, aoi_mode)
+            post_processors = get_postprocessors(post_processors_names)
             message.add(m.Paragraph(self.tr(
                 'The following postprocessors will be used:')))
 


### PR DESCRIPTION
...er.

This parameter is silly from user perspective. Why should user need to check 2 options just to disable a postprocessor? This param was added for #781. As all the postprocessors make sense for both condition (with or without aggregation layer), user can enable/disable just by one checkbox of that postprocessor.