### PR TITLE
Fix #1857 - support OTFP for flood vector building impact

### DIFF
--- a/safe/impact_functions/inundation/flood_vector_building_impact/impact_function.py
+++ b/safe/impact_functions/inundation/flood_vector_building_impact/impact_function.py
@@ -144,7 +144,7 @@ class FloodPolygonBuildingFunction(
         # See issue #1857
         transform = QgsCoordinateTransform(
             QgsCoordinateReferenceSystem(
-                'EPSG:%i') % self._requested_extent_crs,
+                'EPSG:%i' % self._requested_extent_crs),
             hazard_layer.crs()
         )
         projected_extent = transform.transformBoundingBox(requested_extent)

--- a/safe/impact_functions/inundation/flood_vector_building_impact/impact_function.py
+++ b/safe/impact_functions/inundation/flood_vector_building_impact/impact_function.py
@@ -19,6 +19,8 @@ from qgis.core import (
     QgsFeature,
     QgsRectangle,
     QgsFeatureRequest,
+    QgsCoordinateTransform,
+    QgsCoordinateReferenceSystem,
     QgsGeometry)
 from PyQt4.QtCore import QVariant
 
@@ -134,8 +136,20 @@ class FloodPolygonBuildingFunction(
 
         # Filter geometry and data using the requested extent
         requested_extent = QgsRectangle(*self.requested_extent)
+
+        # This is a hack - we should be setting the extent CRS
+        # in the IF base class via safe/engine/core.py:calculate_impact
+        # for now we assume the extent is in 4326 because it
+        # is set to that from geo_extent
+        # See issue #1857
+        transform = QgsCoordinateTransform(
+            QgsCoordinateReferenceSystem(
+                'EPSG:%i') % self._requested_extent_crs,
+            hazard_layer.crs()
+        )
+        projected_extent = transform.transformBoundingBox(requested_extent)
         request = QgsFeatureRequest()
-        request.setFilterRect(requested_extent)
+        request.setFilterRect(projected_extent)
 
         # Split building_layer by H and save as result:
         #   1) Filter from H inundated features
@@ -166,8 +180,9 @@ class FloodPolygonBuildingFunction(
 
         if hazard_poly is None:
             message = tr(
-                'There are no objects in the hazard layer with Affected '
-                'value=%s. Please check the value or use other extent.') % (
+                'There are no objects in the hazard layer with %s '
+                'value=%s. Please check your data or use another attribute.') % (
+                    affected_field,
                     affected_value)
             raise GetDataError(message)
 


### PR DESCRIPTION
If you try to use Vector Flood on Buildings Impact (using the QGIS implementation) you get an error like:

```
Details

These additional details were reported when the problem occurred.

An exception occurred when calculating the results. Calculation error encountered:
There are no objects in the hazard layer with affected (Affected Field) = 1 (Affected Value). Please check the value or use a different extent.
Diagnostics (click for details)

In file "/Users/timlinux/.qgis2/python/plugins/,/safe/utilities/impact_calculator_thread.py", line 188, in run check_integrity=self._check_integrity)
In file "/Users/timlinux/.qgis2/python/plugins/,/safe/engine/core.py", line 184, in calculate_impact F = impact_function.run(layers)
In file "/Users/timlinux/.qgis2/python/plugins/,/safe/impact_functions/inundation/flood_polygon_roads/impact_function.py", line 154, in run raise GetDataError(message)
```


This is because the request extent is in EPSG:4326 whereas the layer is in a different CRS.