### PR TITLE
Fix #1854: Modified aggregation to use impact layer extent 

### DIFF
--- a/safe/gui/widgets/dock.py
+++ b/safe/gui/widgets/dock.py
@@ -1925,8 +1925,7 @@ class Dock(QtGui.QDockWidget, FORM_CLASS):
                 m.Message(
                     LOGO_ELEMENT,
                     m.Heading(
-                        self.tr('Analysis environment ready'),
-                        **INFO_STYLE),
+                        self.tr('Analysis environment ready'), **INFO_STYLE),
                     m.Text(self.tr(
                         'The hazard layer, exposure layer and your '
                         'defined analysis area extents all overlap. Press the '

--- a/safe/impact_functions/generic/classified_polygon_building/impact_function.py
+++ b/safe/impact_functions/generic/classified_polygon_building/impact_function.py
@@ -17,8 +17,8 @@ from safe.storage.vector import Vector
 from safe.utilities.i18n import tr
 from safe.impact_functions.base import ImpactFunction
 from safe.impact_functions.generic.classified_polygon_building\
-    .metadata_definitions import \
-    ClassifiedPolygonHazardBuildingFunctionMetadata
+    .metadata_definitions \
+    import ClassifiedPolygonHazardBuildingFunctionMetadata
 from safe.common.exceptions import InaSAFEError
 from safe.common.utilities import (
     get_thousand_separator,

--- a/safe/impact_functions/generic/continuous_hazard_population/impact_function.py
+++ b/safe/impact_functions/generic/continuous_hazard_population/impact_function.py
@@ -143,8 +143,8 @@ class ContinuousHazardPopulationFunction(ImpactFunction):
         # exposure is in the hazard zone, else just assign 0
         low_exposure = numpy.where(hazard_data < low_t, exposure_data, 0)
         medium_exposure = numpy.where(
-            (hazard_data >= low_t) &
-            (hazard_data < medium_t), exposure_data, 0)
+            (hazard_data >= low_t) & (hazard_data < medium_t),
+            exposure_data, 0)
         high_exposure = numpy.where(
             (hazard_data >= medium_t) & (hazard_data <= high_t),
             exposure_data, 0)

--- a/safe/impact_functions/inundation/flood_polygon_roads/impact_function.py
+++ b/safe/impact_functions/inundation/flood_polygon_roads/impact_function.py
@@ -175,7 +175,8 @@ class FloodVectorRoadsExperimentalFunction(ImpactFunction):
         # Generate simple impact report
         epsg = get_utm_epsg(self.requested_extent[0], self.requested_extent[1])
         destination_crs = QgsCoordinateReferenceSystem(epsg)
-        transform = QgsCoordinateTransform(exposure_layer.crs(), destination_crs)
+        transform = QgsCoordinateTransform(
+            exposure_layer.crs(), destination_crs)
         road_len = flooded_len = 0  # Length of roads
         roads_by_type = dict()      # Length of flooded roads by types
 

--- a/safe/impact_functions/inundation/flood_vector_building_impact/impact_function.py
+++ b/safe/impact_functions/inundation/flood_vector_building_impact/impact_function.py
@@ -181,7 +181,8 @@ class FloodPolygonBuildingFunction(
         if hazard_poly is None:
             message = tr(
                 'There are no objects in the hazard layer with %s '
-                'value=%s. Please check your data or use another attribute.') % (
+                'value=%s. Please check your data or use another '
+                'attribute.') % (
                     affected_field,
                     affected_value)
             raise GetDataError(message)

--- a/safe/impact_functions/volcanic/volcano_polygon_population/metadata_definitions.py
+++ b/safe/impact_functions/volcanic/volcano_polygon_population/metadata_definitions.py
@@ -60,8 +60,8 @@ class VolcanoPolygonPopulationFunctionMetadata(ImpactFunctionMetadata):
             'author': 'AIFDR',
             'date_implemented': 'N/A',
             'hazard_input': tr(
-                'The hazard vector layer must be a polygon that has a specific '
-                'hazard zone attribute.'),
+                'The hazard vector layer must be a polygon that has a '
+                'specific hazard zone attribute.'),
             'exposure_input': tr(
                 'An exposure raster layer where each cell represents a '
                 'population count for that cell.'),

--- a/safe/impact_statistics/aggregator.py
+++ b/safe/impact_statistics/aggregator.py
@@ -124,7 +124,7 @@ class Aggregator(QtCore.QObject):
             'inasafe/use_native_zonal_stats', False, type=bool))
         self.use_native_zonal_stats = flag
 
-        self.extent = extent
+        self._extent = extent
         self._keyword_io = KeywordIO()
         self._defaults = get_defaults()
         self.error_message = None
@@ -170,6 +170,16 @@ class Aggregator(QtCore.QObject):
             keywords = {}
             self.write_keywords(
                 self.layer, keywords)
+
+    @property
+    def extent(self):
+        return self._extent
+
+    @extent.setter
+    def extent(self, value):
+        self._extent = value
+        self._prepare_layer()
+        self.safe_layer = safe_read_layer(str(self.layer.source()))
 
     def read_keywords(self, layer, keyword=None):
         """It is a wrapper around self._keyword_io.read_keywords
@@ -1580,12 +1590,18 @@ class Aggregator(QtCore.QObject):
         fields = provider.fields()
         feature.setFields(fields)
         # noinspection PyCallByClass,PyTypeChecker,PyArgumentList
-        feature.setGeometry(QgsGeometry.fromRect(
+        geom = QgsGeometry.fromRect(
             QgsRectangle(
                 QgsPoint(self.extent[0], self.extent[1]),
-                QgsPoint(self.extent[2], self.extent[3]))))
+                QgsPoint(self.extent[2], self.extent[3])))
+        feature.setGeometry(geom)
         feature[attribute_name] = self.tr('Entire area')
-        provider.addFeatures([feature])
+        if provider.featureCount() > 0:
+            # delete previous feature
+            for f in provider.getFeatures():
+                provider.changeGeometryValues({f.id(): geom})
+        else:
+            provider.addFeatures([feature])
         self.layer.updateExtents()
         try:
             self.update_keywords(

--- a/safe/impact_statistics/aggregator.py
+++ b/safe/impact_statistics/aggregator.py
@@ -178,8 +178,15 @@ class Aggregator(QtCore.QObject):
     @extent.setter
     def extent(self, value):
         self._extent = value
-        self._prepare_layer()
-        self.safe_layer = safe_read_layer(str(self.layer.source()))
+        # update layer extent to match impact layer if in aoi_mode
+        if self.aoi_mode:
+            try:
+                self.layer = self._extents_to_layer()
+                self.safe_layer = safe_read_layer(str(self.layer.source()))
+            except (InvalidLayerError,
+                    UnsupportedProviderError,
+                    KeywordDbError):
+                raise
 
     def read_keywords(self, layer, keyword=None):
         """It is a wrapper around self._keyword_io.read_keywords

--- a/safe/impact_statistics/function_options_dialog.py
+++ b/safe/impact_statistics/function_options_dialog.py
@@ -149,7 +149,6 @@ class FunctionOptionsDialog(QtGui.QDialog, FORM_CLASS):
 
         scroll_layout.addStretch()
 
-
     def build_post_processor_form(self, form_elements):
         """Build Post Processor Tab.
 
@@ -181,7 +180,6 @@ class FunctionOptionsDialog(QtGui.QDialog, FORM_CLASS):
         self.values['postprocessors'] = values
         # spacer needs to be added last
         scroll_layout.addStretch()
-
 
     def build_widget(self, form_layout, name, key_value):
         """Create a new form element dynamically based from key_value type.


### PR DESCRIPTION
Modify aggregation to use impact layer extent if aggregation layer is not provided.

This fix is used to handle cases where the hazard vector layer contains polygon which is outside the optimal extent but must be included in the postprocessor calculations.