### PR TITLE
Fix layer source used converted as unicode

### DIFF
--- a/safe/impact_statistics/aggregator.py
+++ b/safe/impact_statistics/aggregator.py
@@ -182,7 +182,7 @@ class Aggregator(QtCore.QObject):
         if self.aoi_mode:
             try:
                 self.layer = self._extents_to_layer()
-                self.safe_layer = safe_read_layer(str(self.layer.source()))
+                self.safe_layer = safe_read_layer(unicode(self.layer.source()))
             except (InvalidLayerError,
                     UnsupportedProviderError,
                     KeywordDbError):
@@ -439,7 +439,7 @@ class Aggregator(QtCore.QObject):
         except (InvalidLayerError, UnsupportedProviderError, KeywordDbError):
             raise
 
-        self.safe_layer = safe_read_layer(str(self.layer.source()))
+        self.safe_layer = safe_read_layer(unicode(self.layer.source()))
 
     def deintersect(self):
         """Ensure there are no intersecting features with self.layer.


### PR DESCRIPTION
Layer source string was previously converted using str() cast.
By @akbargumbira 's [comments](https://github.com/AIFDR/inasafe/pull/1864#discussion_r28900048), we should change the cast to unicode