### PR TITLE
add IDP camp export and improve GUI

### DIFF
--- a/resources/osm/admin_level_per_country.json
+++ b/resources/osm/admin_level_per_country.json
@@ -1,4 +1,28 @@
 {
+  "Afghanistan": {
+	"1": "N/A",
+	"2": "National Border",
+	"3": "N/A",
+	"4": "Province (ولايت wilayat)",
+	"5": "N/A",
+	"6": "Districts (Wuleswali)",
+	"7": "N/A",
+	"8": "N/A",
+	"9": "N/A",
+	"10": "N/A"
+  },
+  "Ethiopia": {
+	"1": "",
+	"2": "National Borders",
+	"3": "",
+	"4": "Administrative States",
+	"5": "",
+	"6": "Zones",
+	"7": "",
+	"8": "Woreda",
+	"9": "Subcities",
+	"10": "Kebele"
+  },
   "Indonesia": {
 	"1": "N/A",
 	"2": "National Border",
@@ -11,6 +35,43 @@
 	"9": "Neighborhood Unit (Rukun Tetangga)",
 	"10": "N/A"
   },
+  "Madagascar": {
+	"1": "",
+	"2": "National Border",
+	"3": "",
+	"4": "Faritra (regions)",
+	"5": "",
+	"6": "Distrika (districts)",
+	"7": "",
+	"8": "Kaominina (communes)",
+	"9": "",
+	"10": "Fokontany"
+  },
+  "Malawi": {
+	"1": "",
+	"2": "National Border",
+	"3": "Regions",
+	"4": "Districts",
+	"5": "",
+	"6": "Traditional authorities (rural areas), Urban administrative wards (urban centers)",
+	"7": "",
+	"8": "Sub-Chiefs, Wards, Area.",
+	"9": "GVH",
+	"10": "Village"
+  },
+  "Mozambique": {
+	"1": "",
+	"2": "National Border",
+	"3": "",
+	"4": "States (Províncias)",
+	"5": "",
+	"6": "",
+	"7": "",
+	"8": "Municipalities (Municípios)",
+	"9": "Districts (Distritos Municipais)",
+	"10": "Postos Administrativos",
+	"11": "Neighbourhoods (Bairros)"
+  },
   "Philippines": {
 	"1": "N/A",
 	"2": "National Border",
@@ -22,5 +83,17 @@
 	"8": "Other administrative districts (if any)",
 	"9": "Zones (if any)",
 	"10": "Barangays"
+  },
+  "Zimbabwe": {
+	"1": "",
+	"2": "",
+	"3": "",
+	"4": "",
+	"5": "",
+	"6": "",
+	"7": "",
+	"8": "",
+	"9": "",
+	"10": ""
   }
 }

--- a/resources/osm/admin_level_per_country.json
+++ b/resources/osm/admin_level_per_country.json
@@ -1,0 +1,26 @@
+{
+  "Indonesia": {
+	"1": "N/A",
+	"2": "National Border",
+	"3": "N/A",
+	"4": "Province",
+	"5": "City / Regency (Kotamadya / Kabupaten)",
+	"6": "Subdistrict (Kecamatan)",
+	"7": "Village (Kelurahan / Desa)",
+	"8": "Community Group (Rukun Warga)",
+	"9": "Neighborhood Unit (Rukun Tetangga)",
+	"10": "N/A"
+  },
+  "Philippines": {
+	"1": "N/A",
+	"2": "National Border",
+	"3": "Regions",
+	"4": "Provinces",
+	"5": "Sangguniang Panlalawigan (Provincial Council) districts (if any)",
+	"6": "Cities and Municipalities / Towns",
+	"7": "Sangguniang Panlungsod / Bayan (City/Town Council) districts (if any)",
+	"8": "Other administrative districts (if any)",
+	"9": "Zones (if any)",
+	"10": "Barangays"
+  }
+}

--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -81,12 +81,8 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         self.setWindowTitle(self.tr('InaSAFE OpenStreetMap Downloader'))
 
         self.iface = iface
-        self.url = {
-            'buildings': 'http://osm.linfiniti.com/buildings-shp',
-            'building-points': 'http://osm.linfiniti.com/building-points-shp',
-            'roads': 'http://osm.linfiniti.com/roads-shp',
-            'potential-idp': 'http://osm.linfiniti.com/potential-idp-shp'
-        }
+        self.url_osm = 'http://osm.linfiniti.com/'
+        self.url_osm_suffix = '-shp'
 
         self.help_context = 'openstreetmap_downloader'
         # creating progress dialog for download
@@ -560,8 +556,9 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
                 max_latitude=max_latitude
             )
 
+        url = self.url_osm + feature_type + self.url_osm_suffix
         url = '{url}?bbox={box}&qgis_version=2'.format(
-            url=self.url[feature_type], box=box)
+            url=url, box=box)
 
         if 'LANG' in os.environ:
             env_lang = os.environ['LANG']

--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -78,10 +78,12 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         self.setWindowTitle(self.tr('InaSAFE OpenStreetMap Downloader'))
 
         self.iface = iface
-        self.buildings_url = 'http://osm.linfiniti.com/buildings-shp'
-        self.building_points_url = \
-            'http://osm.linfiniti.com/building-points-shp'
-        self.roads_url = 'http://osm.linfiniti.com/roads-shp'
+        self.url = {
+            'buildings': 'http://osm.linfiniti.com/buildings-shp',
+            'building-points': 'http://osm.linfiniti.com/building-points-shp',
+            'roads': 'http://osm.linfiniti.com/roads-shp',
+            'potential-idp': 'http://osm.linfiniti.com/potential-idp-shp'
+        }
 
         self.help_context = 'openstreetmap_downloader'
         # creating progress dialog for download
@@ -307,15 +309,15 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
             return
 
         # Get all the feature types
-        index = self.feature_type.currentIndex()
-        if index == 0:
-            feature_types = ['buildings', 'roads', 'building-points']
-        elif index == 1:
-            feature_types = ['buildings']
-        elif index == 2:
-            feature_types = ['building-points']
-        else:
-            feature_types = ['roads']
+        feature_types = []
+        if self.roads_checkBox.isChecked():
+            feature_types.append('roads')
+        if self.buildings_checkBox.isChecked():
+            feature_types.append('buildings')
+        if self.building_points_checkBox.isChecked():
+            feature_types.append('building-points')
+        if self.potential_idp_checkBox.isChecked():
+            feature_types.append('potential-idp')
 
         try:
             self.save_state()
@@ -493,15 +495,9 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
                 max_longitude=max_longitude,
                 max_latitude=max_latitude
             )
-        if feature_type == 'buildings':
-            url = '{url}?bbox={box}&qgis_version=2'.format(
-                url=self.buildings_url, box=box)
-        elif feature_type == 'building-points':
-            url = '{url}?bbox={box}&qgis_version=2'.format(
-                url=self.building_points_url, box=box)
-        else:
-            url = '{url}?bbox={box}&qgis_version=2'.format(
-                url=self.roads_url, box=box)
+
+        url = '{url}?bbox={box}&qgis_version=2'.format(
+            url=self.url[feature_type], box=box)
 
         if 'LANG' in os.environ:
             env_lang = os.environ['LANG']

--- a/safe/gui/tools/test/test_osm_downloader.py
+++ b/safe/gui/tools/test/test_osm_downloader.py
@@ -187,6 +187,73 @@ class ImportDialogTest(unittest.TestCase):
         # provide Fake QNetworkAccessManager for self.network_manager
         self.dialog.network_manager = FakeQNetworkAccessManager()
 
+    def test_checked_features(self):
+        """Test checked features"""
+        self.dialog.roads_checkBox.setChecked(False)
+        self.dialog.buildings_checkBox.setChecked(False)
+        self.dialog.building_points_checkBox.setChecked(False)
+        self.dialog.potential_idp_checkBox.setChecked(False)
+        self.dialog.boundary_checkBox.setChecked(False)
+        expected = []
+        get = self.dialog.get_checked_features()
+        self.assertItemsEqual(expected, get)
+
+        self.dialog.roads_checkBox.setChecked(True)
+        self.dialog.buildings_checkBox.setChecked(True)
+        self.dialog.building_points_checkBox.setChecked(True)
+        self.dialog.potential_idp_checkBox.setChecked(True)
+        self.dialog.boundary_checkBox.setChecked(False)
+        expected = ['roads', 'buildings', 'building-points', 'potential-idp']
+        get = self.dialog.get_checked_features()
+        self.assertItemsEqual(expected, get)
+
+        admin_level = 6
+        self.dialog.admin_level_comboBox.setCurrentIndex(admin_level - 1)
+        self.dialog.roads_checkBox.setChecked(False)
+        self.dialog.buildings_checkBox.setChecked(True)
+        self.dialog.building_points_checkBox.setChecked(True)
+        self.dialog.potential_idp_checkBox.setChecked(True)
+        self.dialog.boundary_checkBox.setChecked(True)
+        expected = [
+            'buildings', 'building-points', 'potential-idp', 'boundary-6']
+        get = self.dialog.get_checked_features()
+        self.assertItemsEqual(expected, get)
+
+    def test_populate_countries(self):
+        """Test if items are in the combobox.
+        For instance every admin_level from 1 to 11 and
+        the first and last country (alphabetical order)."""
+        self.assertTrue(self.dialog.admin_level_comboBox.count() == 11)
+        self.assertTrue(
+            self.dialog.country_comboBox.itemText(0) == 'Afghanistan')
+        nb_items = self.dialog.country_comboBox.count()
+        self.assertTrue(
+            self.dialog.country_comboBox.itemText(nb_items - 1) == 'Zimbabwe')
+
+    def test_admin_level_helper(self):
+        """Test the helper by setting a country and an admin level"""
+        admin_level = 8
+        country = 'Indonesia'
+        expected = \
+            '<span style=" font-size:12pt; font-style:italic;">, ' \
+            'level 8 is : Community Group (Rukun Warga)</span>'
+
+        self.dialog.admin_level_comboBox.setCurrentIndex(admin_level - 1)
+        index = self.dialog.country_comboBox.findText(country)
+        self.dialog.country_comboBox.setCurrentIndex(index)
+        self.assertTrue(expected == self.dialog.boundary_helper.text())
+
+        admin_level = 6
+        country = 'Madagascar'
+        expected = \
+            '<span style=" font-size:12pt; font-style:italic;">, ' \
+            'level 6 is : Distrika (districts)</span>'
+
+        self.dialog.admin_level_comboBox.setCurrentIndex(admin_level - 1)
+        index = self.dialog.country_comboBox.findText(country)
+        self.dialog.country_comboBox.setCurrentIndex(index)
+        self.assertTrue(expected == self.dialog.boundary_helper.text())
+
     def test_validate_extent(self):
         """Test validate extent method."""
         # Normal case
@@ -244,8 +311,7 @@ class ImportDialogTest(unittest.TestCase):
         url = (
             'http://osm.linfiniti.com/buildings-shp?'
             'bbox=20.389938354492188,-34.10782492987083'
-            ',20.712661743164062,'
-            '-34.008273470938335&obj=%s' % feature)
+            ',20.712661743164062,-34.008273470938335')
         path = tempfile.mktemp('shapefiles')
         self.dialog.fetch_zip(url, path, feature)
 

--- a/safe/gui/ui/osm_downloader_dialog_base.ui
+++ b/safe/gui/ui/osm_downloader_dialog_base.ui
@@ -277,7 +277,7 @@
       <item>
        <widget class="QCheckBox" name="potential_idp_checkBox">
         <property name="text">
-         <string extracomment="Internally displaced person">Potential internally displaced person camp</string>
+         <string extracomment="Internally displaced person">Potential internally displaced person camps</string>
         </property>
         <property name="checked">
          <bool>true</bool>

--- a/safe/gui/ui/osm_downloader_dialog_base.ui
+++ b/safe/gui/ui/osm_downloader_dialog_base.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>519</width>
-    <height>594</height>
+    <width>612</width>
+    <height>664</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,80 +17,85 @@
    <property name="spacing">
     <number>10</number>
    </property>
-   <item row="1" column="0">
-    <widget class="QLabel" name="feature_type_label">
+   <item row="10" column="0">
+    <widget class="QCheckBox" name="overwrite_checkBox">
+     <property name="styleSheet">
+      <string notr="true">padding-bottom: 10px;</string>
+     </property>
      <property name="text">
-      <string>Feature Type</string>
+      <string>Overwrite existing files</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLineEdit" name="output_directory">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="directory_button">
-       <property name="text">
-        <string>...</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Feature type</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="roads_checkBox">
+        <property name="text">
+         <string>Roads</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="buildings_checkBox">
+        <property name="text">
+         <string>Buildings (polygon)</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="building_points_checkBox">
+        <property name="text">
+         <string>Buildings (point)</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="potential_idp_checkBox">
+        <property name="text">
+         <string extracomment="Internally displaced person">Potential internally displaced person camp</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
-   <item row="5" column="0">
+   <item row="8" column="0">
     <widget class="QLabel" name="filename_prefix_label">
      <property name="text">
       <string>File name prefix</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="output_directory_label">
-     <property name="text">
-      <string>Output directory</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QComboBox" name="feature_type">
-     <item>
-      <property name="text">
-       <string>All</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Buildings</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Building points</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Roads</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLineEdit" name="filename_prefix">
-     <property name="inputMask">
-      <string extracomment="Only A-Z a-z 0-9 and -_ chars allowed"/>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
+   <item row="11" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
@@ -114,8 +119,11 @@
       <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <property name="spacing">
-       <number>10</number>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
       </property>
       <item row="3" column="0">
        <widget class="QLabel" name="label">
@@ -179,7 +187,7 @@
      </layout>
     </widget>
    </item>
-   <item row="9" column="0">
+   <item row="12" column="0">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -190,21 +198,52 @@
     </widget>
    </item>
    <item row="0" column="0">
-    <widget class="QWebView" name="web_view">
-     <property name="url">
+    <widget class="QWebView" name="web_view" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>100</height>
+      </size>
+     </property>
+     <property name="url" stdset="0">
       <url>
        <string>about:blank</string>
       </url>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QCheckBox" name="overwrite_checkBox">
-     <property name="styleSheet">
-      <string notr="true">padding-bottom: 10px;</string>
+   <item row="9" column="0">
+    <widget class="QLineEdit" name="filename_prefix">
+     <property name="inputMask">
+      <string extracomment="Only A-Z a-z 0-9 and -_ chars allowed"/>
      </property>
      <property name="text">
-      <string>Overwrite existing files</string>
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="output_directory">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="directory_button">
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="output_directory_label">
+     <property name="text">
+      <string>Output directory</string>
      </property>
     </widget>
    </item>

--- a/safe/gui/ui/osm_downloader_dialog_base.ui
+++ b/safe/gui/ui/osm_downloader_dialog_base.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>612</width>
-    <height>664</height>
+    <height>759</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,47 @@
    <property name="spacing">
     <number>10</number>
    </property>
-   <item row="10" column="0">
+   <item row="3" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt; font-style:italic;&quot;&gt;For information, in&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="country_comboBox"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="boundary_helper">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="11" column="0">
     <widget class="QCheckBox" name="overwrite_checkBox">
      <property name="styleSheet">
       <string notr="true">padding-bottom: 10px;</string>
@@ -27,75 +67,14 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Feature type</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-     <property name="flat">
-      <bool>true</bool>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QCheckBox" name="roads_checkBox">
-        <property name="text">
-         <string>Roads</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="buildings_checkBox">
-        <property name="text">
-         <string>Buildings (polygon)</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="building_points_checkBox">
-        <property name="text">
-         <string>Buildings (point)</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="potential_idp_checkBox">
-        <property name="text">
-         <string extracomment="Internally displaced person">Potential internally displaced person camp</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="8" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="filename_prefix_label">
      <property name="text">
       <string>File name prefix</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="0">
+   <item row="12" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
@@ -187,7 +166,7 @@
      </layout>
     </widget>
    </item>
-   <item row="12" column="0">
+   <item row="13" column="0">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -212,7 +191,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0">
+   <item row="10" column="0">
     <widget class="QLineEdit" name="filename_prefix">
      <property name="inputMask">
       <string extracomment="Only A-Z a-z 0-9 and -_ chars allowed"/>
@@ -222,7 +201,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLineEdit" name="output_directory">
@@ -240,11 +219,86 @@
      </item>
     </layout>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="output_directory_label">
      <property name="text">
       <string>Output directory</string>
      </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Feature type</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="roads_checkBox">
+        <property name="text">
+         <string>Roads</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="buildings_checkBox">
+        <property name="text">
+         <string>Buildings (polygon)</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="building_points_checkBox">
+        <property name="text">
+         <string>Buildings (point)</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="potential_idp_checkBox">
+        <property name="text">
+         <string extracomment="Internally displaced person">Potential internally displaced person camp</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QCheckBox" name="boundary_checkBox">
+          <property name="text">
+           <string>Political boundaries</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="admin_level_comboBox"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Add two options to download potential IDP and boundaries.
![osm_downloader](https://cloud.githubusercontent.com/assets/1609292/7522983/ed8394a8-f4f8-11e4-8656-78d4307807cd.jpg)

Shapefiles need to be improved on osm-reporter.
All options are checked by default, except boundary.

The combobox about the country is optional. That's why I put it in a sentence which is italic.
