### PR TITLE
fix volcano polygon population metadata to not accept hazard point layer

### DIFF
--- a/safe/impact_functions/volcanic/volcano_polygon_population/metadata_definitions.py
+++ b/safe/impact_functions/volcanic/volcano_polygon_population/metadata_definitions.py
@@ -83,10 +83,7 @@ class VolcanoPolygonPopulationFunctionMetadata(ImpactFunctionMetadata):
             'layer_requirements': {
                 'hazard': {
                     'layer_mode': layer_mode_classified,
-                    'layer_geometries': [
-                        layer_geometry_polygon,
-                        layer_geometry_point
-                    ],
+                    'layer_geometries': [layer_geometry_polygon],
                     'hazard_categories': [hazard_category_multi_hazard],
                     'hazard_types': [hazard_volcano],
                     'continuous_hazard_units': [],


### PR DESCRIPTION
If it is allowed to accept point hazard, the function can't handle it and raises exception.

@akbargumbira @ismailsunni if you are ok with this, just merge it.