### PR TITLE
Improve the boundary export in the OSM downloader

### DIFF
--- a/resources/osm/admin_level_per_country.json
+++ b/resources/osm/admin_level_per_country.json
@@ -1,99 +1,124 @@
 {
   "Afghanistan": {
-	"1": "N/A",
-	"2": "National Border",
-	"3": "N/A",
-	"4": "Province (ولايت wilayat)",
-	"5": "N/A",
-	"6": "Districts (Wuleswali)",
-	"7": "N/A",
-	"8": "N/A",
-	"9": "N/A",
-	"10": "N/A"
+	"_comments": "BBOX format : West, North, East, South",
+	"bbox": [60.33, 38.56, 75.03, 29.32],
+	"levels": {
+	  "1": "N/A",
+	  "2": "National Border",
+	  "3": "N/A",
+	  "4": "Province (ولايت wilayat)",
+	  "5": "N/A",
+	  "6": "Districts (Wuleswali)",
+	  "7": "N/A",
+	  "8": "N/A",
+	  "9": "N/A",
+	  "10": "N/A"
+	}
   },
   "Ethiopia": {
-	"1": "",
-	"2": "National Borders",
-	"3": "",
-	"4": "Administrative States",
-	"5": "",
-	"6": "Zones",
-	"7": "",
-	"8": "Woreda",
-	"9": "Subcities",
-	"10": "Kebele"
+	"bbox": [32.89, 14.95, 48.05, 3.29],
+	"levels": {
+	  "1": "",
+	  "2": "National Borders",
+	  "3": "",
+	  "4": "Administrative States",
+	  "5": "",
+	  "6": "Zones",
+	  "7": "",
+	  "8": "Woreda",
+	  "9": "Subcities",
+	  "10": "Kebele"
+	}
   },
   "Indonesia": {
-	"1": "N/A",
-	"2": "National Border",
-	"3": "N/A",
-	"4": "Province",
-	"5": "City / Regency (Kotamadya / Kabupaten)",
-	"6": "Subdistrict (Kecamatan)",
-	"7": "Village (Kelurahan / Desa)",
-	"8": "Community Group (Rukun Warga)",
-	"9": "Neighborhood Unit (Rukun Tetangga)",
-	"10": "N/A"
+	"bbox": [94.96, 7.01, 141.54, -11.65],
+	"levels": {
+	  "1": "N/A",
+	  "2": "National Border",
+	  "3": "N/A",
+	  "4": "Province",
+	  "5": "City / Regency (Kotamadya / Kabupaten)",
+	  "6": "Subdistrict (Kecamatan)",
+	  "7": "Village (Kelurahan / Desa)",
+	  "8": "Community Group (Rukun Warga)",
+	  "9": "Neighborhood Unit (Rukun Tetangga)",
+	  "10": "N/A"
+	}
   },
   "Madagascar": {
-	"1": "",
-	"2": "National Border",
-	"3": "",
-	"4": "Faritra (regions)",
-	"5": "",
-	"6": "Distrika (districts)",
-	"7": "",
-	"8": "Kaominina (communes)",
-	"9": "",
-	"10": "Fokontany"
+	"bbox": [42.75, -11.69, 50.84, -25.74],
+	"levels": {
+	  "1": "",
+	  "2": "National Border",
+	  "3": "",
+	  "4": "Faritra (regions)",
+	  "5": "",
+	  "6": "Distrika (districts)",
+	  "7": "",
+	  "8": "Kaominina (communes)",
+	  "9": "",
+	  "10": "Fokontany"
+	}
   },
   "Malawi": {
-	"1": "",
-	"2": "National Border",
-	"3": "Regions",
-	"4": "Districts",
-	"5": "",
-	"6": "Traditional authorities (rural areas), Urban administrative wards (urban centers)",
-	"7": "",
-	"8": "Sub-Chiefs, Wards, Area.",
-	"9": "GVH",
-	"10": "Village"
+	"bbox": [32.59, -9.29, 35.95, -17.16],
+	"levels": {
+	  "1": "",
+	  "2": "National Border",
+	  "3": "Regions",
+	  "4": "Districts",
+	  "5": "",
+	  "6": "Traditional authorities (rural areas), Urban administrative wards (urban centers)",
+	  "7": "",
+	  "8": "Sub-Chiefs, Wards, Area.",
+	  "9": "GVH",
+	  "10": "Village"
+	}
   },
   "Mozambique": {
-	"1": "",
-	"2": "National Border",
-	"3": "",
-	"4": "States (Províncias)",
-	"5": "",
-	"6": "",
-	"7": "",
-	"8": "Municipalities (Municípios)",
-	"9": "Districts (Distritos Municipais)",
-	"10": "Postos Administrativos",
-	"11": "Neighbourhoods (Bairros)"
+	"bbox": [30.08, -9.14, 41.04, -26.98],
+	"levels": {
+	  "1": "",
+	  "2": "National Border",
+	  "3": "",
+	  "4": "States (Províncias)",
+	  "5": "",
+	  "6": "",
+	  "7": "",
+	  "8": "Municipalities (Municípios)",
+	  "9": "Districts (Distritos Municipais)",
+	  "10": "Postos Administrativos",
+	  "11": "Neighbourhoods (Bairros)"
+	}
   },
   "Philippines": {
-	"1": "N/A",
-	"2": "National Border",
-	"3": "Regions",
-	"4": "Provinces",
-	"5": "Sangguniang Panlalawigan (Provincial Council) districts (if any)",
-	"6": "Cities and Municipalities / Towns",
-	"7": "Sangguniang Panlungsod / Bayan (City/Town Council) districts (if any)",
-	"8": "Other administrative districts (if any)",
-	"9": "Zones (if any)",
-	"10": "Barangays"
+	"bbox": [114, 21, 128, 5],
+	"levels": {
+	  "1": "N/A",
+	  "2": "National Border",
+	  "3": "Regions",
+	  "4": "Provinces",
+	  "5": "Sangguniang Panlalawigan (Provincial Council) districts (if any)",
+	  "6": "Cities and Municipalities / Towns",
+	  "7": "Sangguniang Panlungsod / Bayan (City/Town Council) districts (if any)",
+	  "8": "Other administrative districts (if any)",
+	  "9": "Zones (if any)",
+	  "10": "Barangays"
+	}
   },
   "Zimbabwe": {
-	"1": "",
-	"2": "",
-	"3": "",
-	"4": "",
-	"5": "",
-	"6": "",
-	"7": "",
-	"8": "",
-	"9": "",
-	"10": ""
+	"bbox": [24.65, -15.40, 33.18, -22.47],
+	"levels": {
+	  "1": "",
+	  "2": "",
+	  "3": "",
+	  "4": "",
+	  "5": "",
+	  "6": "",
+	  "7": "",
+	  "8": "",
+	  "9": "",
+	  "10": ""
+	}
   }
 }

--- a/safe/gui/tools/osm_downloader_dialog.py
+++ b/safe/gui/tools/osm_downloader_dialog.py
@@ -23,7 +23,7 @@ import logging
 
 # noinspection PyUnresolvedReferences
 # pylint: disable=unused-import
-from qgis.core import QGis  # force sip2 api
+from qgis.core import QGis, QgsRectangle  # force sip2 api
 from qgis.gui import QgsMapToolPan
 # pylint: enable=unused-import
 
@@ -120,12 +120,12 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         # Setup pan tool
         self.pan_tool = QgsMapToolPan(self.canvas)
         self.canvas.setMapTool(self.pan_tool)
-        self.update_extent_from_map_canvas()
 
         # Setup helper for admin_level
         json_file_path = resources_path('osm', 'admin_level_per_country.json')
         if os.path.isfile(json_file_path):
             self.countries = json.load(open(json_file_path))
+            self.bbox_countries = None
             self.populate_countries()
             # connect
             self.country_comboBox.currentIndexChanged.connect(
@@ -133,13 +133,16 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
             self.admin_level_comboBox.currentIndexChanged.connect(
                 self.update_helper_political_level)
 
+        self.update_extent_from_map_canvas()
+
     def update_helper_political_level(self):
         """To update the helper about the country and the admin_level."""
         current_country = self.country_comboBox.currentText()
         index = self.admin_level_comboBox.currentIndex()
         current_level = self.admin_level_comboBox.itemData(index)
         try:
-            content = self.countries[current_country][str(current_level)]
+            content = \
+                self.countries[current_country]['levels'][str(current_level)]
             if content == 'N/A' or content == 'fixme' or content == '':
                 raise KeyError
         except KeyError:
@@ -161,6 +164,13 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         list_countries.sort()
         for country in list_countries:
             self.country_comboBox.addItem(country)
+
+        self.bbox_countries = {}
+        for country in list_countries:
+            coords = self.countries[country]['bbox']
+            self.bbox_countries[country] = QgsRectangle(
+                coords[0], coords[3], coords[2], coords[1])
+
         self.update_helper_political_level()
 
     def show_info(self):
@@ -253,6 +263,17 @@ class OsmDownloaderDialog(QDialog, FORM_CLASS):
         self.min_latitude.setText(str(extent[1]))
         self.max_longitude.setText(str(extent[2]))
         self.max_latitude.setText(str(extent[3]))
+
+        # Updating the country if possible.
+        rectangle = QgsRectangle(extent[0], extent[1], extent[2], extent[3])
+        center = rectangle.center()
+        for country in self.bbox_countries:
+            if self.bbox_countries[country].contains(center):
+                index = self.country_comboBox.findText(country)
+                self.country_comboBox.setCurrentIndex(index)
+                break
+        else:
+            self.country_comboBox.setCurrentIndex(0)
 
     def update_extent_from_map_canvas(self):
         """Update extent value in GUI based from value in map.

--- a/safe/gui/tools/test/test_osm_downloader.py
+++ b/safe/gui/tools/test/test_osm_downloader.py
@@ -219,6 +219,26 @@ class ImportDialogTest(unittest.TestCase):
         get = self.dialog.get_checked_features()
         self.assertItemsEqual(expected, get)
 
+    def test_detect_country(self):
+        """Test if the country is well detected according to the extent."""
+        # Extent in Zimbabwe.
+        self.dialog.update_extent([29.4239, -18.2391, 29.4676, -18.2068])
+        index = self.dialog.country_comboBox.currentIndex()
+        country = self.dialog.country_comboBox.itemText(index)
+        self.assertTrue(country == 'Zimbabwe')
+
+        # Extent in Indonesia.
+        self.dialog.update_extent([106.7741, -6.2609, 106.8874, -6.1859])
+        index = self.dialog.country_comboBox.currentIndex()
+        country = self.dialog.country_comboBox.itemText(index)
+        self.assertTrue(country == 'Indonesia')
+
+        # Extent in the middle of nowhere in the Indian Ocean, default value.
+        self.dialog.update_extent([75.0586, -31.7477, 75.8867, -30.9022])
+        index = self.dialog.country_comboBox.currentIndex()
+        country = self.dialog.country_comboBox.itemText(index)
+        self.assertTrue(country == 'Afghanistan')
+
     def test_populate_countries(self):
         """Test if items are in the combobox.
         For instance every admin_level from 1 to 11 and
@@ -231,7 +251,7 @@ class ImportDialogTest(unittest.TestCase):
             self.dialog.country_comboBox.itemText(nb_items - 1) == 'Zimbabwe')
 
     def test_admin_level_helper(self):
-        """Test the helper by setting a country and an admin level"""
+        """Test the helper by setting a country and an admin level."""
         admin_level = 8
         country = 'Indonesia'
         expected = \

--- a/safe/gui/ui/osm_downloader_dialog_base.ui
+++ b/safe/gui/ui/osm_downloader_dialog_base.ui
@@ -17,47 +17,22 @@
    <property name="spacing">
     <number>10</number>
    </property>
-   <item row="3" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="label_5">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt; font-style:italic;&quot;&gt;For information, in&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="country_comboBox"/>
-     </item>
-     <item>
-      <widget class="QLabel" name="boundary_helper">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+   <item row="0" column="0">
+    <widget class="QWebView" name="web_view" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>100</height>
+      </size>
+     </property>
+     <property name="url" stdset="0">
+      <url>
+       <string>about:blank</string>
+      </url>
+     </property>
+    </widget>
    </item>
-   <item row="11" column="0">
+   <item row="12" column="0">
     <widget class="QCheckBox" name="overwrite_checkBox">
      <property name="styleSheet">
       <string notr="true">padding-bottom: 10px;</string>
@@ -67,14 +42,14 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0">
+   <item row="10" column="0">
     <widget class="QLabel" name="filename_prefix_label">
      <property name="text">
       <string>File name prefix</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="0">
+   <item row="13" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
@@ -166,7 +141,7 @@
      </layout>
     </widget>
    </item>
-   <item row="13" column="0">
+   <item row="14" column="0">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -176,22 +151,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QWebView" name="web_view" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>100</height>
-      </size>
-     </property>
-     <property name="url" stdset="0">
-      <url>
-       <string>about:blank</string>
-      </url>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
+   <item row="11" column="0">
     <widget class="QLineEdit" name="filename_prefix">
      <property name="inputMask">
       <string extracomment="Only A-Z a-z 0-9 and -_ chars allowed"/>
@@ -201,7 +161,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="9" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLineEdit" name="output_directory">
@@ -219,7 +179,7 @@
      </item>
     </layout>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0">
     <widget class="QLabel" name="output_directory_label">
      <property name="text">
       <string>Output directory</string>
@@ -284,6 +244,18 @@
         </property>
        </widget>
       </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string/>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
@@ -294,7 +266,61 @@
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="admin_level_comboBox"/>
+         <widget class="QComboBox" name="admin_level_comboBox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_help_1">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt; font-style:italic;&quot;&gt;In&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="country_comboBox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="boundary_helper">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>is : undefined</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>
@@ -341,6 +367,70 @@
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>boundary_checkBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_help_1</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>157</x>
+     <y>277</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>380</x>
+     <y>313</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>boundary_checkBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>boundary_helper</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>157</x>
+     <y>277</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>546</x>
+     <y>313</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>boundary_checkBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>country_comboBox</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>157</x>
+     <y>277</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>440</x>
+     <y>313</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>boundary_checkBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>admin_level_comboBox</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>157</x>
+     <y>277</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>453</x>
+     <y>277</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
- Change the GUI about the political boundary.
- add the bbox to each country in the json file.
- detect if the center of the map canvas is in one of these countries.
  - if yes, select this country in the combobox.

![osm_downloader](https://cloud.githubusercontent.com/assets/1609292/7983616/7ba7e6e2-0ac2-11e5-9c6c-8fb5227bf350.jpg)
