### PR TITLE
Make flood vector-building impact function faster

### DIFF
--- a/safe/impact_functions/inundation/flood_vector_building_impact/impact_function.py
+++ b/safe/impact_functions/inundation/flood_vector_building_impact/impact_function.py
@@ -14,6 +14,7 @@ Contact : ole.moller.nielsen@gmail.com
 from collections import OrderedDict
 from qgis.core import (
     QgsField,
+    QgsSpatialIndex,
     QgsVectorLayer,
     QgsFeature,
     QgsRectangle,
@@ -153,25 +154,18 @@ class FloodPolygonBuildingFunction(
         if affected_field_type in ['Real', 'Integer']:
             affected_value = float(affected_value)
 
-        hazard_data = hazard_layer.getFeatures(request)
-        hazard_poly = None
-        for feature in hazard_data:
-            record = feature.attributes()
-            if record[affected_field_index] != affected_value:
+        # make spatial index of affected polygons
+        hazard_index = QgsSpatialIndex()
+        hazard_geometries = {}  # key = feature id, value = geometry
+        has_hazard_objects = False
+        for feature in hazard_layer.getFeatures(request):
+            if feature[affected_field_index] != affected_value:
                 continue
-            if hazard_poly is None:
-                hazard_poly = QgsGeometry(feature.geometry())
-            else:
-                # Make geometry union of inundated polygons
-                # But some polygon.geometry() could be invalid, skip them
-                tmp_geometry = hazard_poly.combine(feature.geometry())
-                try:
-                    if tmp_geometry.isGeosValid():
-                        hazard_poly = tmp_geometry
-                except AttributeError:
-                    pass
+            hazard_index.insertFeature(feature)
+            hazard_geometries[feature.id()] = QgsGeometry(feature.geometry())
+            has_hazard_objects = True
 
-        if hazard_poly is None:
+        if not has_hazard_objects:
             message = tr(
                 'There are no objects in the hazard layer with %s '
                 'value=%s. Please check your data or use another '
@@ -180,18 +174,31 @@ class FloodPolygonBuildingFunction(
                     affected_value)
             raise GetDataError(message)
 
-        exposure_data = exposure_layer.getFeatures(request)
-        for feature in exposure_data:
+        features = []
+        for feature in exposure_layer.getFeatures(request):
             building_geom = feature.geometry()
-            record = feature.attributes()
-            l_feat = QgsFeature()
-            l_feat.setGeometry(building_geom)
-            l_feat.setAttributes(record)
-            if hazard_poly.intersects(building_geom):
-                l_feat.setAttribute(target_field_index, 1)
-            else:
-                l_feat.setAttribute(target_field_index, 0)
-            (_, __) = building_layer.dataProvider().addFeatures([l_feat])
+            affected = False
+            # get tentative list of intersecting hazard features
+            # only based on intersection of bounding boxes
+            ids = hazard_index.intersects(building_geom.boundingBox())
+            for fid in ids:
+                # run (slow) exact intersection test
+                if hazard_geometries[fid].intersects(building_geom):
+                    affected = True
+                    break
+            f = QgsFeature()
+            f.setGeometry(building_geom)
+            f.setAttributes(feature.attributes())
+            f[target_field_index] = 1 if affected else 0
+            features.append(f)
+
+            # every once in a while commit the created features
+            # to the output layer
+            if len(features) == 1000:
+                (_, __) = building_provider.addFeatures(features)
+                features = []
+
+        (_, __) = building_provider.addFeatures(features)
         building_layer.updateExtents()
 
         # Generate simple impact report


### PR DESCRIPTION
This is done by using spatial index to identify which flood polygons
will need exact intersection test (much faster than doing intersection
with one huge polygon)

A small extra optimization is to write features in batches as that is
more efficient than writing features one by one.

Measured speed improvement on Jakarta test data (2013 flood polygons
and OSM buildings) was ~40x (from 30min down to 40sec)

Fixes #1889