### PR TITLE
Classified hazard vs polygon building with QGIS API

### DIFF
--- a/safe/common/utilities.py
+++ b/safe/common/utilities.py
@@ -18,6 +18,8 @@ import colorsys
 from collections import OrderedDict
 # pylint: enable=unused-import
 
+from PyQt4.QtCore import QPyNullVariant
+
 from safe.common.exceptions import VerificationError
 from safe.utilities.i18n import locale
 
@@ -747,12 +749,16 @@ def get_osm_building_usage(attribute_names, feature):
     attribute_names_lower = [
         attribute_name.lower() for attribute_name in attribute_names]
 
+    # if the feature is from QGIS layer, NULL values are represented
+    # by QPyNullVariant instead of None, so we handle that explicitly
+
     usage = None
     # Prioritize 'type' attribute
     if 'type' in attribute_names_lower:
         attribute_index = attribute_names_lower.index('type')
         field_name = attribute_names[attribute_index]
-        usage = feature[field_name]
+        if not isinstance(feature[field_name], QPyNullVariant):
+            usage = feature[field_name]
 
     # Get the usage from other attribute names
     building_type_attributes = ['amenity', 'building_t', 'office', 'tourism',
@@ -762,13 +768,15 @@ def get_osm_building_usage(attribute_names, feature):
             attribute_index = attribute_names_lower.index(
                 type_attribute)
             field_name = attribute_names[attribute_index]
-            usage = feature[field_name]
+            if not isinstance(feature[field_name], QPyNullVariant):
+                usage = feature[field_name]
 
     # The last one is to get it from 'building' attribute
     if 'building' in attribute_names_lower and usage is None:
         attribute_index = attribute_names_lower.index('building')
         field_name = attribute_names[attribute_index]
-        usage = feature[field_name]
+        if not isinstance(feature[field_name], QPyNullVariant):
+            usage = feature[field_name]
 
         if usage is not None and usage.lower() == 'yes':
             usage = 'building'

--- a/safe/engine/interpolation_qgis.py
+++ b/safe/engine/interpolation_qgis.py
@@ -1,0 +1,129 @@
+# coding=utf-8
+"""InaSAFE Disaster risk tool by Australian Aid
+
+
+.. note:: This program is free software; you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+     the Free Software Foundation; either version 2 of the License, or
+     (at your option) any later version.
+
+"""
+
+from qgis.core import (
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsFeature,
+    QgsFeatureRequest,
+    QgsField,
+    QgsGeometry,
+    QgsRectangle,
+    QgsSpatialIndex
+)
+from PyQt4.QtCore import QVariant
+
+from safe.gis.qgis_vector_tools import create_layer
+
+
+def interpolate_polygon_polygon(source, target, wgs84_extent):
+    """ Transfer values from source polygon layer to the target polygon layer.
+
+    This method will do a spatial join: the output layer will contain all
+    features from target layer, with the addition of attributes of intersecting
+    feature from the source layer. If there is not intersecting source feature,
+    the output layer will still contain the target feature, with null
+    attributes from the source layer.
+
+    The intersection test considers only centroids of target features
+    (not the whole polygon geometry).
+
+    If more features from source layer intersect a target feature, only
+    the first intersecting source feature will be used.
+
+    :param source: Source polygon layer
+    :type source: QgsVectorLayer
+
+    :param target: Target polygon layer
+    :type target: QgsVectorLayer
+
+    :param wgs84_extent: Requested extent for analysis, in WGS84 coordinates
+    :type wgs84_extent: QgsRectangle
+
+    :return: output layer
+    :rtype: QgsVectorLayer
+    """
+
+    source_field_count = source.dataProvider().fields().count()
+    target_field_count = target.dataProvider().fields().count()
+
+    # Create new layer for writing resulting features.
+    # It will contain attributes of both target and source layers
+    result = create_layer(target)
+    new_fields = source.dataProvider().fields().toList()
+    new_fields.append(QgsField('polygon_id', QVariant.Int))
+    result.dataProvider().addAttributes(new_fields)
+    result.updateFields()
+    result_fields = result.dataProvider().fields()
+
+    # setup transform objects between different CRS
+    crs_wgs84 = QgsCoordinateReferenceSystem("EPSG:4326")
+    wgs84_to_source = QgsCoordinateTransform(crs_wgs84, source.crs())
+    wgs84_to_target = QgsCoordinateTransform(crs_wgs84, target.crs())
+    source_to_target = QgsCoordinateTransform(source.crs(), target.crs())
+
+    # compute extents in CRS of layers
+    source_extent = wgs84_to_source.transformBoundingBox(wgs84_extent)
+    target_extent = wgs84_to_target.transformBoundingBox(wgs84_extent)
+
+    # cache source layer (in CRS of target layer)
+    source_index = QgsSpatialIndex()
+    source_geometries = {}  # key = feature ID, value = QgsGeometry
+    source_attributes = {}
+    for f in source.getFeatures(QgsFeatureRequest(source_extent)):
+        f.geometry().transform(source_to_target)
+        source_index.insertFeature(f)
+        source_geometries[f.id()] = QgsGeometry(f.geometry())
+        source_attributes[f.id()] = f.attributes()
+
+    # Go through all features in target layer and for each decide
+    # whether it is intersected by any source feature
+    result_features = []
+    for f in target.getFeatures(QgsFeatureRequest(target_extent)):
+        # we use just centroids of target polygons
+        centroid_geometry = f.geometry().centroid()
+        centroid = centroid_geometry.asPoint()
+        rect = QgsRectangle(
+            centroid.x(), centroid.y(),
+            centroid.x(), centroid.y())
+        ids = source_index.intersects(rect)
+
+        has_matching_source = False
+        for source_id in ids:
+            if source_geometries[source_id].intersects(centroid_geometry):
+                # we have found intersection between source and target
+                f_result = QgsFeature(result_fields)
+                f_result.setGeometry(f.geometry())
+                for i in xrange(target_field_count):
+                    f_result[i] = f[i]
+                for i in xrange(source_field_count):
+                    f_result[i+target_field_count] = \
+                        source_attributes[source_id][i]
+                f_result['polygon_id'] = source_id
+                result_features.append(f_result)
+                has_matching_source = True
+                break   # assuming just one source for each target feature
+
+        # if there is no intersecting feature from source layer,
+        # we will keep the source attributes null
+        if not has_matching_source:
+            f_result = QgsFeature(result_fields)
+            f_result.setGeometry(f.geometry())
+            for i in xrange(target_field_count):
+                f_result[i] = f[i]
+            result_features.append(f_result)
+
+        if len(result_features) == 1000:
+            result.dataProvider().addFeatures(result_features)
+            result_features = []
+
+    result.dataProvider().addFeatures(result_features)
+    return result

--- a/safe/engine/test/test_interpolation_qgis.py
+++ b/safe/engine/test/test_interpolation_qgis.py
@@ -1,0 +1,139 @@
+# coding=utf-8
+"""Tests for interpolation functionality done with QGIS API."""
+
+import unittest
+
+from qgis.core import QgsFeatureRequest, QgsVectorLayer
+
+from safe.test.utilities import get_qgis_app, TESTDATA
+from safe.gis.qgis_vector_tools import create_layer
+from safe.engine.interpolation_qgis import interpolate_polygon_polygon
+
+QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
+
+
+class TestInterpolationQGIS(unittest.TestCase):
+    """Test for interpolation functionality done with QGIS API"""
+
+    def test_interpolation_from_polygons_one_poly(self):
+        """Point interpolation using one polygon from Maumere works
+
+        There's a test with the same name in test_engine.py not using QGIS API.
+        This one deals correctly with holes in polygons,
+        so the resulting numbers are a bit different.
+        """
+
+        # Name file names for hazard level and exposure
+        hazard_filename = ('%s/tsunami_polygon_WGS84.shp' % TESTDATA)
+        exposure_filename = ('%s/building_Maumere.shp' % TESTDATA)
+
+        # Read input data
+        H_all = QgsVectorLayer(hazard_filename, 'Hazard', 'ogr')
+
+        # Cut down to make test quick
+        # Polygon #799 is the one used in separate test
+        H = create_layer(H_all)
+        polygon799 = H_all.getFeatures(QgsFeatureRequest(799)).next()
+        H.dataProvider().addFeatures([polygon799])
+
+        E = QgsVectorLayer(exposure_filename, 'Exposure', 'ogr')
+
+        # Test interpolation function
+        I = interpolate_polygon_polygon(H, E, E.extent())
+
+        N = I.dataProvider().featureCount()
+        assert N == I.dataProvider().featureCount()
+
+        # Assert that expected attribute names exist
+        I_names = [field.name() for field in I.dataProvider().fields()]
+        for field in H.dataProvider().fields():
+            name = field.name()
+            msg = 'Did not find hazard name "%s" in %s' % (name, I_names)
+            assert name in I_names, msg
+
+        for field in E.dataProvider().fields():
+            name = field.name()
+            msg = 'Did not find exposure name "%s" in %s' % (name, I_names)
+            assert name in I_names, msg
+
+        # Verify interpolated values with test result
+        count = 0
+        for f in I.getFeatures():
+            category = f['Category']
+            if category is not None:
+                count += 1
+
+        msg = ('Expected 453 points tagged with category, '
+               'but got only %i' % count)
+        assert count == 453, msg
+
+    def test_interpolation_from_polygons_multiple(self):
+        """Point interpolation using multiple polygons from Maumere works
+
+        There's a test with the same name in test_engine.py not using QGIS API.
+        This one deals correctly with holes in polygons,
+        so the resulting numbers are a bit different.
+        """
+
+        # Name file names for hazard and exposure
+        hazard_filename = ('%s/tsunami_polygon_WGS84.shp' % TESTDATA)
+        exposure_filename = ('%s/building_Maumere.shp' % TESTDATA)
+
+        # Read input data
+        H = QgsVectorLayer(hazard_filename, 'Hazard', 'ogr')
+
+        E = QgsVectorLayer(exposure_filename, 'Exposure', 'ogr')
+
+        # Test interpolation function
+        I = interpolate_polygon_polygon(H, E, E.extent())
+
+        N = I.dataProvider().featureCount()
+        assert N == E.dataProvider().featureCount()
+
+        # Assert that expected attribute names exist
+        I_names = [field.name() for field in I.dataProvider().fields()]
+        for field in H.dataProvider().fields():
+            name = field.name()
+            msg = 'Did not find hazard name "%s" in %s' % (name, I_names)
+            assert name in I_names, msg
+
+        for field in E.dataProvider().fields():
+            name = field.name()
+            msg = 'Did not find exposure name "%s" in %s' % (name, I_names)
+            assert name in I_names, msg
+
+        # Verify interpolated values with test result
+        counts = {}
+        for f in I.getFeatures():
+
+            # Count items in each specific category
+            category = f['Category']
+            if category not in counts:
+                counts[category] = 0
+            counts[category] += 1
+
+        assert H.dataProvider().featureCount() == 1032
+        assert I.dataProvider().featureCount() == 3528
+
+        # The full version
+        msg = ('Expected 2267 points tagged with category "High", '
+               'but got only %i' % counts['High'])
+        assert counts['High'] == 2267, msg
+
+        msg = ('Expected 1179 points tagged with category "Very High", '
+               'but got only %i' % counts['Very High'])
+        assert counts['Very High'] == 1179, msg
+
+        msg = ('Expected 2 points tagged with category "Medium" '
+               'but got only %i' % counts['Medium'])
+        assert counts['Medium'] == 2, msg
+
+        msg = ('Expected 4 points tagged with category "Low" '
+               'but got only %i' % counts['Low'])
+        assert counts['Low'] == 4, msg
+
+        msg = ('Expected 76 points tagged with no category '
+               'but got only %i' % counts[None])
+        assert counts[None] == 76, msg
+
+    test_interpolation_from_polygons_multiple.slow = True

--- a/safe/impact_functions/generic/classified_polygon_building/impact_function.py
+++ b/safe/impact_functions/generic/classified_polygon_building/impact_function.py
@@ -13,6 +13,9 @@ Contact : ole.moller.nielsen@gmail.com
 
 from collections import OrderedDict
 
+from qgis.core import QgsField, QgsRectangle
+from PyQt4.QtCore import QVariant
+
 from safe.impact_functions.bases.classified_vh_classified_ve import \
     ClassifiedVHClassifiedVE
 from safe.storage.vector import Vector
@@ -25,10 +28,9 @@ from safe.common.utilities import (
     get_thousand_separator,
     get_osm_building_usage,
     color_ramp)
-from safe.engine.interpolation import (
-    assign_hazard_values_to_exposure_data)
 from safe.impact_reports.building_exposure_report_mixin import (
     BuildingExposureReportMixin)
+from safe.engine.interpolation_qgis import interpolate_polygon_polygon
 
 
 class ClassifiedPolygonHazardBuildingFunction(
@@ -81,48 +83,63 @@ class ClassifiedPolygonHazardBuildingFunction(
         hazard_zone_attribute = self.parameters['hazard zone attribute'].value
 
         # Identify hazard and exposure layers
-        hazard_layer = self.hazard
-        exposure_layer = self.exposure
+        hazard_layer = self.hazard.get_layer()
+        exposure_layer = self.exposure.get_layer()
 
         # Input checks
-        if not hazard_layer.is_polygon_data:
-            message = (
-                'Input hazard must be a polygon. I got %s with '
-                'layer type %s' %
-                (hazard_layer.get_name(), hazard_layer.get_geometry_name()))
-            raise Exception(message)
+        # TODO[MD]: isn't this check enforced by metadata?
+        #if not hazard_layer.is_polygon_data:
+        #    message = (
+        #        'Input hazard must be a polygon. I got %s with '
+        #        'layer type %s' %
+        #        (hazard_layer.get_name(), hazard_layer.get_geometry_name()))
+        #    raise Exception(message)
+
+        hazard_zone_attribute_index = hazard_layer.fieldNameIndex(
+            hazard_zone_attribute)
 
         # Check if hazard_zone_attribute exists in hazard_layer
-        if hazard_zone_attribute not in hazard_layer.get_attribute_names():
+        if hazard_zone_attribute_index < 0:
             message = (
                 'Hazard data %s does not contain expected attribute %s ' %
-                (hazard_layer.get_name(), hazard_zone_attribute))
+                (hazard_layer.name(), hazard_zone_attribute))
             # noinspection PyExceptionInherit
             raise InaSAFEError(message)
 
         # Hazard zone categories from hazard layer
-        self.hazard_zones = list(
-            set(hazard_layer.get_data(hazard_zone_attribute)))
+        self.hazard_zones = hazard_layer.uniqueValues(
+            hazard_zone_attribute_index)
 
         self.buildings = {}
         self.affected_buildings = OrderedDict()
         for hazard_zone in self.hazard_zones:
             self.affected_buildings[hazard_zone] = {}
 
+        wgs84_extent = QgsRectangle(
+            self.requested_extent[0], self.requested_extent[1],
+            self.requested_extent[2], self.requested_extent[3])
+
         # Run interpolation function for polygon2polygon
-        interpolated_layer = assign_hazard_values_to_exposure_data(
-            hazard_layer, exposure_layer, attribute_name=None)
+        interpolated_layer = interpolate_polygon_polygon(
+            hazard_layer, exposure_layer, wgs84_extent)
+
+        new_field = QgsField(self.target_field, QVariant.String)
+        interpolated_layer.dataProvider().addAttributes([new_field])
+        interpolated_layer.updateFields()
+
+        attribute_names = [field.name() for field in
+                           interpolated_layer.pendingFields()]
+        target_field_index = interpolated_layer.fieldNameIndex(
+            self.target_field)
+        changed_values = {}
 
         # Extract relevant interpolated data
-        attribute_names = interpolated_layer.get_attribute_names()
-        features = interpolated_layer.get_data()
-
-        for i in range(len(features)):
-            hazard_value = features[i][hazard_zone_attribute]
+        for feature in interpolated_layer.getFeatures():
+            hazard_value = feature[hazard_zone_attribute]
             if not hazard_value:
                 hazard_value = self._not_affected_value
-            features[i][self.target_field] = hazard_value
-            usage = get_osm_building_usage(attribute_names, features[i])
+            changed_values[feature.id()] = {target_field_index: hazard_value}
+            usage = get_osm_building_usage(attribute_names, feature)
             if usage is None:
                 usage = tr('Unknown')
             if usage not in self.buildings:
@@ -134,6 +151,8 @@ class ClassifiedPolygonHazardBuildingFunction(
             if hazard_value in self.affected_buildings.keys():
                 self.affected_buildings[hazard_value][usage][
                     tr('Buildings Affected')] += 1
+
+        interpolated_layer.dataProvider().changeAttributeValues(changed_values)
 
         # Lump small entries and 'unknown' into 'other' category
         self._consolidate_to_other()
@@ -172,9 +191,7 @@ class ClassifiedPolygonHazardBuildingFunction(
 
         # Create vector layer and return
         impact_layer = Vector(
-            data=features,
-            projection=interpolated_layer.get_projection(),
-            geometry=interpolated_layer.get_geometry(),
+            data=interpolated_layer,
             name=tr('Buildings affected by each hazard zone'),
             keywords={'impact_summary': impact_summary,
                       'impact_table': impact_table,

--- a/safe/impact_functions/generic/classified_polygon_building/metadata_definitions.py
+++ b/safe/impact_functions/generic/classified_polygon_building/metadata_definitions.py
@@ -55,7 +55,7 @@ class ClassifiedPolygonHazardBuildingFunctionMetadata(ImpactFunctionMetadata):
             'name': tr('Classified polygon hazard on buildings'),
             'impact': tr('Be affected'),
             'title': tr('Be affected'),
-            'function_type': 'old-style',
+            'function_type': 'qgis2.0',
             'author': 'Akbar Gumbira (akbargumbira@gmail.com)',
             'date_implemented': '17/04/2015',
             'overview': tr(

--- a/safe/impact_functions/generic/classified_polygon_building/test/test_classified_polygon_building.py
+++ b/safe/impact_functions/generic/classified_polygon_building/test/test_classified_polygon_building.py
@@ -19,8 +19,10 @@ import unittest
 from safe.impact_functions.impact_function_manager import ImpactFunctionManager
 from safe.impact_functions.generic.classified_polygon_building.impact_function\
     import ClassifiedPolygonHazardBuildingFunction
-from safe.test.utilities import test_data_path
-from safe.storage.core import read_layer
+from safe.test.utilities import get_qgis_app, test_data_path
+from qgis.core import QgsVectorLayer
+
+QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 
 
 class TestClassifiedPolygonBuildingFunction(unittest.TestCase):
@@ -37,12 +39,19 @@ class TestClassifiedPolygonBuildingFunction(unittest.TestCase):
             'hazard', 'classified_generic_polygon.shp')
         building_path = test_data_path('exposure', 'buildings.shp')
 
-        hazard_layer = read_layer(generic_polygon_path)
-        exposure_layer = read_layer(building_path)
+        hazard_layer = QgsVectorLayer(generic_polygon_path, 'Hazard', 'ogr')
+        exposure_layer = QgsVectorLayer(building_path, 'Buildings', 'ogr')
+
+        # Let's set the extent to the hazard extent
+        extent = hazard_layer.extent()
+        rect_extent = [
+            extent.xMinimum(), extent.yMaximum(),
+            extent.xMaximum(), extent.yMinimum()]
 
         impact_function = ClassifiedPolygonHazardBuildingFunction.instance()
         impact_function.hazard = hazard_layer
         impact_function.exposure = exposure_layer
+        impact_function.requested_extent = rect_extent
         impact_function.parameters['hazard zone attribute'].value = 'h_zone'
         impact_function.run()
         impact_layer = impact_function.impact
@@ -62,7 +71,7 @@ class TestClassifiedPolygonBuildingFunction(unittest.TestCase):
         # The result
         expected_high_count = 11
         expected_medium_count = 161
-        expected_low_count = 0
+        expected_low_count = 2
         message = 'Expecting %s for High Hazard Zone, but it returns %s' % (
             high_zone_count, expected_high_count)
         self.assertEqual(high_zone_count, expected_high_count, message)


### PR DESCRIPTION
This PR makes the ClassifiedPolygonHazardBuildingFunction work by using QGIS API instead of using InaSAFE's own routines for geometry operations.

It has been discovered that InaSAFE's geometry operations do not handle polygons with holes correctly, the new functionality comes with unit tests that give slightly different results (differences were manually checked to confirm that the new results are correct).

This implementation may be faster than the original with many smaller hazard polygons, and slower than the original with few very complex polygons. The speed could be improved probably by using prepared geometries or by cutting complex polygons into smaller pieces.