### PR TITLE
[IFCWizard] Fix test for layer overlap. Fixes #1957

### DIFF
--- a/safe/gui/tools/wizard_dialog.py
+++ b/safe/gui/tools/wizard_dialog.py
@@ -3139,7 +3139,7 @@ class WizardDialog(QDialog, FORM_CLASS):
         """
         extent_a = layer_a.extent()
         extent_b = layer_b.extent()
-        if self.iface.mapCanvas().hasCrsTransformEnabled():
+        if layer_a.crs() != layer_b.crs():
             coordTransform = QgsCoordinateTransform(layer_a.crs(),
                                                     layer_b.crs())
             extent_b = (coordTransform.transform(


### PR DESCRIPTION
After adding a layer with a different CRS, the overlap test goes faster than the signal that enables the OTFR.