### PR TITLE
Align raster layers using QGIS functionality

### DIFF
--- a/safe/common/exceptions.py
+++ b/safe/common/exceptions.py
@@ -258,6 +258,9 @@ class CallGDALError(Exception):
     not empty"""
     pass
 
+class AlignRastersError(Exception):
+    """Raised if alignment of hazard and exposure rasters failed"""
+    pass
 
 class ImportDialogError(Exception):
     """Raised if import process failed."""

--- a/safe/utilities/analysis.py
+++ b/safe/utilities/analysis.py
@@ -58,7 +58,11 @@ from safe.utilities.gis import (
     viewport_geo_array,
     extent_to_array)
 from safe.utilities.utilities import get_error_message
-from safe.utilities.clipper import clip_layer, adjust_clip_extent
+from safe.utilities.clipper import (
+    clip_layer,
+    adjust_clip_extent,
+    qgis_align_rasters_available,
+    qgis_align_rasters)
 from safe.messaging import styles
 from safe.common.signals import (
     DYNAMIC_MESSAGE_SIGNAL,
@@ -776,10 +780,18 @@ class Analysis(object):
             adjusted_geo_extent = self.clip_parameters[1]
             cell_size = self.clip_parameters[2]
             exposure_layer = self.clip_parameters[3]
-            # geo_extent = self.clip_parameters[4]
+            geo_extent = self.clip_parameters[4]
             hazard_layer = self.clip_parameters[5]
         except:
             raise
+
+        # when working with two raster layers, it is best to use align
+        # rasters tool from QGIS if it is available
+        if qgis_align_rasters_available() and \
+                exposure_layer.type() == QgsMapLayer.RasterLayer and \
+                hazard_layer.type() == QgsMapLayer.RasterLayer:
+            return qgis_align_rasters(hazard_layer, exposure_layer, geo_extent)
+
         # Make sure that we have EPSG:4326 versions of the input layers
         # that are clipped and (in the case of two raster inputs) resampled to
         # the best resolution.

--- a/safe/utilities/analysis.py
+++ b/safe/utilities/analysis.py
@@ -790,7 +790,15 @@ class Analysis(object):
         if qgis_align_rasters_available() and \
                 exposure_layer.type() == QgsMapLayer.RasterLayer and \
                 hazard_layer.type() == QgsMapLayer.RasterLayer:
-            return qgis_align_rasters(hazard_layer, exposure_layer, geo_extent)
+            # get exposure's keywords to decide how to perform the alignment
+            rescale_values = self.exposure_keyword.get(
+                'exposure_unit') == 'count'
+            allow_resampling = self.exposure_keyword.get(
+                'allow_resampling', 'true').lower() == 'true'
+            # do the resampling using QGIS
+            return qgis_align_rasters(
+                hazard_layer, exposure_layer, geo_extent,
+                rescale_values, allow_resampling)
 
         # Make sure that we have EPSG:4326 versions of the input layers
         # that are clipped and (in the case of two raster inputs) resampled to


### PR DESCRIPTION
The PR implements a new way of clipping and resampling of rasters within InaSAFE - see RFC #1998 for more details.

In order to test the new functionality one needs QGIS raster alignment tool - currently only available in my branch:
https://github.com/wonder-sk/QGIS/tree/raster-alignment-tool

If the QGIS raster alignment tool is not present, InaSAFE will use the original code path.
