### PR TITLE
bugfix for issues #2229 and #2233.

### DIFF
--- a/safe/utilities/clipper.py
+++ b/safe/utilities/clipper.py
@@ -246,7 +246,7 @@ def _clip_vector_layer(
 
     writer = QgsVectorFileWriter(
         file_name,
-        'UTF-8',
+        None,
         field_list,
         layer.wkbType(),
         geo_crs,

--- a/safe/utilities/test/test_clipper.py
+++ b/safe/utilities/test/test_clipper.py
@@ -672,6 +672,10 @@ class ClipperTest(unittest.TestCase):
         """Test clipping vector layer with unicode attribute in feature.
 
         This issue is described at Github #2262 and #2233
+        TODO: FIXME:
+        This is a hacky fix. See above ticket for further explanation.
+        To fix this, we should be able to specify UTF-8 encoding for
+        QgsVectorFileWriter
         """
         # this layer contains unicode values in the
         layer_path = test_data_path('boundaries', 'district_osm_jakarta.shp')
@@ -690,13 +694,11 @@ class ClipperTest(unittest.TestCase):
             explode_attribute=aggregation_attribute)
 
         # cross check vector layer attribute in clipped layer
-        field_index = vector_layer.fieldNameIndex(aggregation_attribute)
         vector_values = []
         for f in vector_layer.getFeatures():
             vector_values.append(f.attributes())
 
         clipped_values = []
-        field_index = clipped_layer.fieldNameIndex(aggregation_attribute)
         for f in clipped_layer.getFeatures():
             clipped_values.append(f.attributes())
 

--- a/safe/utilities/test/test_clipper.py
+++ b/safe/utilities/test/test_clipper.py
@@ -10,7 +10,9 @@ Contact : ole.moller.nielsen@gmail.com
      (at your option) any later version.
 
 """
+from safe.defaults import get_defaults
 from safe.utilities.gis import qgis_version
+from safe.utilities.keyword_io import KeywordIO
 
 __author__ = 'tim@kartoza.com'
 __date__ = '20/01/2011'
@@ -665,6 +667,40 @@ class ClipperTest(unittest.TestCase):
         message = 'The adjusted extent should be %s, instead it gives %s' % (
             expected_adjusted_extent, adjusted_extent)
         self.assertEqual(adjusted_extent, expected_adjusted_extent, message)
+
+    def test_clip_vector_with_unicode(self):
+        """Test clipping vector layer with unicode attribute in feature.
+
+        This issue is described at Github #2262 and #2233
+        """
+        layer_path = test_data_path('boundaries', 'district_osm_jakarta.shp')
+        vector_layer = QgsVectorLayer(layer_path, 'District Jakarta', 'ogr')
+        keyword_io = KeywordIO()
+        aggregation_keyword = get_defaults()['AGGR_ATTR_KEY']
+        aggregation_attribute = keyword_io.read_keywords(
+            vector_layer, keyword=aggregation_keyword)
+        source_extent = vector_layer.extent()
+        extent = [source_extent.xMinimum(), source_extent.yMinimum(),
+                  source_extent.xMaximum(), source_extent.yMaximum()]
+        clipped_layer = clip_layer(
+            layer=vector_layer,
+            extent=extent,
+            explode_flag=True,
+            explode_attribute=aggregation_attribute)
+
+        # cross check vector layer attribute in clipped layer
+        field_index = vector_layer.fieldNameIndex(aggregation_attribute)
+        vector_values = []
+        for f in vector_layer.getFeatures():
+            vector_values.append(f[field_index])
+
+        clipped_values = []
+        field_index = clipped_layer.fieldNameIndex(aggregation_attribute)
+        for f in clipped_layer.getFeatures():
+            clipped_values.append(f[field_index])
+
+        for val in clipped_values:
+            self.assertIn(val, vector_values)
 
 if __name__ == '__main__':
     suite = unittest.makeSuite(ClipperTest, 'test')

--- a/safe/utilities/test/test_clipper.py
+++ b/safe/utilities/test/test_clipper.py
@@ -673,6 +673,7 @@ class ClipperTest(unittest.TestCase):
 
         This issue is described at Github #2262 and #2233
         """
+        # this layer contains unicode values in the
         layer_path = test_data_path('boundaries', 'district_osm_jakarta.shp')
         vector_layer = QgsVectorLayer(layer_path, 'District Jakarta', 'ogr')
         keyword_io = KeywordIO()
@@ -692,12 +693,12 @@ class ClipperTest(unittest.TestCase):
         field_index = vector_layer.fieldNameIndex(aggregation_attribute)
         vector_values = []
         for f in vector_layer.getFeatures():
-            vector_values.append(f[field_index])
+            vector_values.append(f.attributes())
 
         clipped_values = []
         field_index = clipped_layer.fieldNameIndex(aggregation_attribute)
         for f in clipped_layer.getFeatures():
-            clipped_values.append(f[field_index])
+            clipped_values.append(f.attributes())
 
         for val in clipped_values:
             self.assertIn(val, vector_values)


### PR DESCRIPTION
What is being addressed #2229 and #2233:

See #2233 for reference

- Stuck in entire area mode if choosing aggregation layer without closing the dialog
- User should be able to merge in entire area mode, even if one of the layer is aggregated, both or none
- Hacky fix for naming bug in reports where it can't match unicode area names. Should be fine for ASCII
- Additional checks to make sure both layers are aggregated with the same aggregation layers with what the user choose.
- Additional checks to make sure that the user uses aggregated postprocessor in both layers if user choose aggregation layer