### PR TITLE
Better keywords table generation

### DIFF
--- a/safe/definitions.py
+++ b/safe/definitions.py
@@ -296,23 +296,17 @@ hazard_all = [
     hazard_generic
 ]
 
-hazard = {
-    'key': 'hazard',
-    'name': tr('Hazard'),
+# Renamed key from hazard to hazards in 3.2 because key was not unique TS
+hazards = {
+    'key': 'hazards',
+    'name': tr('Hazards'),
     'description': tr(
         '<b>Hazards</b> (also called disasters) are what we call the data '
         'layers that describe the extent and magnitude of natural events '
         '(such as earthquakes, tsunamis and volcanic eruptions) that could '
         'potentially cause an event or series of events that threaten and '
         'disrupt the lives and livelihoods of people.'),
-    'types': [
-        hazard_flood,
-        hazard_tsunami,
-        hazard_earthquake,
-        hazard_volcano,
-        hazard_volcanic_ash,
-        hazard_generic
-    ]
+    'types': hazard_all
 }
 
 # Exposure
@@ -371,19 +365,14 @@ exposure_all = [
     exposure_structure
 ]
 
-exposure = {
-    'key': 'exposure',
-    'name': tr('Exposure'),
+# Renamed key from exposure to exposures in 3.2 because key was not unique TS
+exposures = {
+    'key': 'exposures',
+    'name': tr('Exposures'),
     'description': tr(
         '<b>Exposure</b> data represents things that are at risk when faced '
         'with a potential hazard. '),
-    'types': [
-        exposure_land_cover,
-        exposure_people_in_building,
-        exposure_population,
-        exposure_road,
-        exposure_structure
-    ]
+    'types': exposure_all
 }
 
 # Continuous Hazard Unit
@@ -765,4 +754,13 @@ volcano_name_field = {
     'name': tr('Volcano name attribute'),
     'type': 'field',
     'description': tr('Attribute where the volcano name is located.')
+}
+
+# General terminology and descriptive terms
+
+value_map = {
+    'key': 'value_map',
+    'name': tr('Vector classes'),
+    'description': tr(
+        'Vector classes are used to group features with similar meanings. ')
 }

--- a/safe/utilities/test/test_keyword_io.py
+++ b/safe/utilities/test/test_keyword_io.py
@@ -247,6 +247,26 @@ class KeywordIOTest(unittest.TestCase):
             copied_keywords, expected_keywords, out_path)
         self.assertDictEqual(copied_keywords, expected_keywords, message)
 
+    def test_definition(self):
+        """Test we can get definitions for keywords.
+
+        .. versionadded:: 3.2
+
+        """
+        keyword = 'hazards'
+        definition = self.keyword_io.definition(keyword)
+        self.assertTrue(definition.has_key('description'))
+
+    def test_to_message(self):
+        """Test we can convert keywords to a message object.
+
+        .. versionadded:: 3.2
+
+        """
+        keywords = self.keyword_io.read_keywords(self.vector_layer)
+        message = self.keyword_io.to_message(keywords).to_text()
+        self.assertIn('Exposure*structure------', message)
+
 if __name__ == '__main__':
     suite = unittest.makeSuite(KeywordIOTest)
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
Implementation for #2313 - let the keywords table keys be shown from definitions list rather. Also refactored the keywords table generation into keywords.io so that it can be re-used elsewhere...

I also made some other tidy ups to definitions.py