### PR TITLE
fix #2343 - Use InaSAFE uri for osm downloader

### DIFF
--- a/docs/en/openstreetmap_downloader.html
+++ b/docs/en/openstreetmap_downloader.html
@@ -184,7 +184,7 @@ OpenStreetMap project for you.</p>
 <p class="caption">OpenStreetMap Downloader</p>
 </div>
 <p>The tool requires internet connection as it fetches the data via a web service
-running on <a class="reference external" href="http://osm.linfiniti.com">Linfiniti&#8217;s OSM Reporter</a> web site.</p>
+running on <a class="reference external" href="http://osm.inasafe.org">InaSAFE&#8217;s OSM Reporter</a> web site.</p>
 <p>The data, once downloaded will be available to you as a shapefile.
 A style file is automatically created so that it symbolises nicely in QGIS.
 In addition, the correct keyword metadata is created for the downloaded dataset

--- a/docs/id/openstreetmap_downloader.html
+++ b/docs/id/openstreetmap_downloader.html
@@ -183,7 +183,7 @@
 <a class="reference internal image-reference" href="_images/openstreetmap_downloader.png"><img alt="OpenStreetMap Downloader" src="_images/openstreetmap_downloader.png" style="width: 393.0px; height: 474.0px;" /></a>
 <p class="caption">OpenStreetMap Downloader</p>
 </div>
-<p>Tool ini membutuhkan koneksi internet karena tool ini mengambil data dari layanan situs <a class="reference external" href="http://osm.linfiniti.com">Laporan OSM Linfiniti</a></p>
+<p>Tool ini membutuhkan koneksi internet karena tool ini mengambil data dari layanan situs <a class="reference external" href="http://osm.inasafe.org">Laporan OSM InaSAFE</a></p>
 <p>Data, setelah didownload akan tersedia untuk Anda sebagai sebuah shapefile. Sebuah gaya file secara otomatis dibuat sehingga dilambangkan dengan baik dalam QGIS. Selain itu, metadata kata kunci yang benar dibuat untuk dataset didownload sehingga dapat digunakan secara langsung dalam skenario analisis dampak menggunakan InaSAFE.</p>
 <div class="admonition note">
 <p class="first admonition-title">Catatan</p>

--- a/safe/utilities/osm_downloader.py
+++ b/safe/utilities/osm_downloader.py
@@ -31,7 +31,7 @@ from safe.utilities.file_downloader import FileDownloader
 from safe.common.exceptions import DownloadError, CanceledImportDialogError
 from safe.common.version import get_version
 
-URL_OSM_PREFIX = 'http://osm.linfiniti.com/'
+URL_OSM_PREFIX = 'http://osm.inasafe.org/'
 URL_OSM_SUFFIX = '-shp'
 
 LOGGER = logging.getLogger('InaSAFE')

--- a/safe/utilities/test/test_osm_downloader.py
+++ b/safe/utilities/test/test_osm_downloader.py
@@ -149,7 +149,7 @@ class FakeQNetworkAccessManager:
             reply._url = 'http://hot-export.geofabrik.de/jobs/1990'
         elif url == 'http://hot-export.geofabrik.de/jobs/1990':
             reply.content = read_all('test-importdlg-job.html')
-        elif url == ('http://osm.linfiniti.com/buildings-shp?'
+        elif url == ('http://osm.inasafe.org/buildings-shp?'
                      'bbox=20.389938354492188,-34.10782492987083'
                      ',20.712661743164062,'
                      '-34.008273470938335&qgis_version=2'
@@ -196,7 +196,7 @@ class OsmDownloaderTest(unittest.TestCase):
         """
         feature = 'buildings'
         url = (
-            'http://osm.linfiniti.com/buildings-shp?'
+            'http://osm.inasafe.org/buildings-shp?'
             'bbox=20.389938354492188,-34.10782492987083'
             ',20.712661743164062,-34.008273470938335')
         path = tempfile.mktemp('shapefiles')


### PR DESCRIPTION
This PR changes the upstream osm downloader server URL to one hosted on InaSAFE infrastructure.