### PR TITLE
Make parameter widgets look more beautiful

### DIFF
--- a/safe_extras/parameters/qt_widgets/boolean_parameter_widget.py
+++ b/safe_extras/parameters/qt_widgets/boolean_parameter_widget.py
@@ -25,12 +25,18 @@ class BooleanParameterWidget(GenericParameterWidget):
         """
         super(BooleanParameterWidget, self).__init__(parameter, parent)
 
-        self._check_box_input = QCheckBox()
+        # Get the parameter label and use its value as the checkbox text
+        label_item = self._input_layout.itemAt(0)
+        label_widget = label_item.widget()
+        text = label_widget.text()
+
+        self._check_box_input = QCheckBox(text)
         # Tooltips
         self.setToolTip('Tick here to enable ' + self._parameter.name)
         self._check_box_input.setChecked(self._parameter.value)
 
-        self._inner_input_layout.addWidget(self._check_box_input)
+        self._inner_input_layout.insertWidget(0, self._check_box_input)
+        self._input_layout.removeItem(label_item)
 
     def get_parameter(self):
         """Obtain boolean parameter object from the current widget state.

--- a/safe_extras/parameters/qt_widgets/generic_parameter_widget.py
+++ b/safe_extras/parameters/qt_widgets/generic_parameter_widget.py
@@ -70,10 +70,15 @@ class GenericParameterWidget(QWidget, object):
 
         # spacing
         self._main_layout.setSpacing(0)
+        self._main_layout.setContentsMargins(0, 0, 0, 0)
         self._input_layout.setSpacing(0)
+        self._input_layout.setContentsMargins(0, 0, 0, 0)
         self._help_layout.setSpacing(0)
+        self._help_layout.setContentsMargins(0, 0, 0, 0)
         self._inner_input_layout.setSpacing(7)
+        self._inner_input_layout.setContentsMargins(0, 0, 0, 0)
         self._inner_help_layout.setSpacing(0)
+        self._inner_help_layout.setContentsMargins(0, 0, 0, 0)
 
         # Put elements into layouts
         self._input_layout.addWidget(self._label)

--- a/safe_extras/parameters/qt_widgets/group_parameter_widget.py
+++ b/safe_extras/parameters/qt_widgets/group_parameter_widget.py
@@ -24,6 +24,7 @@ class GroupParameterWidget(GenericParameterWidget):
         """
         super(GroupParameterWidget, self).__init__(parameter, parent)
 
+        # Get the parameter label and use its value as the checkbox text
         label_item = self._input_layout.itemAt(0)
         label_widget = label_item.widget()
         text = label_widget.text()
@@ -37,6 +38,7 @@ class GroupParameterWidget(GenericParameterWidget):
 
         if not self._parameter.is_required:
             self._input_layout.insertWidget(0, self._enable_check_box)
+            # now we don't need the parameter label anymore so chuck it
             self._input_layout.removeItem(label_item)
             # Make the sub group appear indented
             self._group_layout.setContentsMargins(20, 0, 0, 0)

--- a/safe_extras/parameters/qt_widgets/group_parameter_widget.py
+++ b/safe_extras/parameters/qt_widgets/group_parameter_widget.py
@@ -6,8 +6,7 @@ __filename__ = 'list_parameter_widget'
 __date__ = '02/04/15'
 __copyright__ = 'lana.pcfre@gmail.com'
 
-from PyQt4.QtGui import (
-    QVBoxLayout, QCheckBox)
+from PyQt4.QtGui import QVBoxLayout, QCheckBox
 
 from qt_widgets.generic_parameter_widget import GenericParameterWidget
 
@@ -25,21 +24,28 @@ class GroupParameterWidget(GenericParameterWidget):
         """
         super(GroupParameterWidget, self).__init__(parameter, parent)
 
-        self._enable_check_box = QCheckBox()
+        label_item = self._input_layout.itemAt(0)
+        label_widget = label_item.widget()
+        text = label_widget.text()
+        self._enable_check_box = QCheckBox(text)
         # Tooltips
         self.setToolTip('Tick here to enable ' + self._parameter.name)
-
-        if not self._parameter.is_required:
-            self._inner_input_layout.addWidget(self._enable_check_box)
-        else:
-            self._parameter.enable_parameter = True
 
         # add all widget in the group
         self._group_layout = QVBoxLayout()
         self._group_layout.setSpacing(0)
 
+        if not self._parameter.is_required:
+            self._input_layout.insertWidget(0, self._enable_check_box)
+            self._input_layout.removeItem(label_item)
+            # Make the sub group appear indented
+            self._group_layout.setContentsMargins(20, 0, 0, 0)
+        else:
+            self._parameter.enable_parameter = True
+
         self._main_layout.addLayout(self._group_layout)
 
+        # Why are we doing imports here? TS
         from qt_widgets.parameter_container import ParameterContainer
 
         self.param_container = ParameterContainer(

--- a/safe_extras/parameters/qt_widgets/parameter_container.py
+++ b/safe_extras/parameters/qt_widgets/parameter_container.py
@@ -194,9 +194,9 @@ class ParameterContainer(QWidget, object):
                 color = color_odd
             i += 1
             parameter_widget.setAutoFillBackground(True)
-            palette = parameter_widget.palette()
-            palette.setColor(parameter_widget.backgroundRole(), color)
-            parameter_widget.setPalette(palette)
+            #palette = parameter_widget.palette()
+            #palette.setColor(parameter_widget.backgroundRole(), color)
+            #parameter_widget.setPalette(palette)
             self.vertical_layout.addWidget(parameter_widget)
 
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)

--- a/safe_extras/parameters/qt_widgets/parameter_container.py
+++ b/safe_extras/parameters/qt_widgets/parameter_container.py
@@ -141,8 +141,8 @@ class ParameterContainer(QWidget, object):
         # Label for description
         self.description_label.setText(self.description_text)
 
-        self.group_frame.setLineWidth(1)
-        self.group_frame.setFrameStyle(QFrame.Panel)
+        self.group_frame.setLineWidth(0)
+        self.group_frame.setFrameStyle(QFrame.NoFrame)
         vlayout = QVBoxLayout()
         vlayout.setContentsMargins(0, 0, 0, 0)
         vlayout.setSpacing(0)


### PR DESCRIPTION
fix #2355 - this fix:

* remove excess padding making parameters more compact
* removes zebra striping of widgets
* puts checkbox labels to the right of checkboxes
* hides frame borders to flatten everything out.

Here is the before view:

![screenshot from 2015-09-11 13-35-09](https://cloud.githubusercontent.com/assets/178003/9813929/3b51db14-588a-11e5-92ea-3ec422ebb43d.png)

and here is what it looks like with my PR:

![screenshot from 2015-09-11 13-31-58](https://cloud.githubusercontent.com/assets/178003/9813931/4717aab4-588a-11e5-8b62-d96f3c1f1b52.png)

