### PR TITLE
update label typo for ISO metadata (s/19155/19115/)

### DIFF
--- a/i18n/inasafe_af.ts
+++ b/i18n/inasafe_af.ts
@@ -5789,7 +5789,7 @@ to
     </message>
     <message>
         <location filename="options_dialog_base.ui" line="422"/>
-        <source>ISO 19155 Metadata</source>
+        <source>ISO 19115 Metadata</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/i18n/inasafe_en.ts
+++ b/i18n/inasafe_en.ts
@@ -5746,7 +5746,7 @@ to
     </message>
     <message>
         <location filename="options_dialog_base.ui" line="422"/>
-        <source>ISO 19155 Metadata</source>
+        <source>ISO 19115 Metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/inasafe_es_ES.ts
+++ b/i18n/inasafe_es_ES.ts
@@ -5810,8 +5810,8 @@ to
     </message>
     <message>
         <location filename="options_dialog_base.ui" line="422"/>
-        <source>ISO 19155 Metadata</source>
-        <translation>Metadatos ISO 19155</translation>
+        <source>ISO 19115 Metadata</source>
+        <translation>Metadatos ISO 19115</translation>
     </message>
     <message>
         <location filename="options_dialog_base.ui" line="67"/>

--- a/i18n/inasafe_fr.ts
+++ b/i18n/inasafe_fr.ts
@@ -5809,7 +5809,7 @@ to
     </message>
     <message>
         <location filename="options_dialog_base.ui" line="422"/>
-        <source>ISO 19155 Metadata</source>
+        <source>ISO 19115 Metadata</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/i18n/inasafe_id.ts
+++ b/i18n/inasafe_id.ts
@@ -5846,8 +5846,8 @@ ke
     </message>
     <message>
         <location filename="options_dialog_base.ui" line="422"/>
-        <source>ISO 19155 Metadata</source>
-        <translation>ISO 19155 Metadata</translation>
+        <source>ISO 19115 Metadata</source>
+        <translation>ISO 19115 Metadata</translation>
     </message>
     <message>
         <location filename="options_dialog_base.ui" line="67"/>

--- a/safe/gui/ui/options_dialog_base.ui
+++ b/safe/gui/ui/options_dialog_base.ui
@@ -419,7 +419,7 @@
      </widget>
      <widget class="QWidget" name="tab_iso19115">
       <attribute name="title">
-       <string>ISO 19155 Metadata</string>
+       <string>ISO 19115 Metadata</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>


### PR DESCRIPTION
Per subject.  Note that there binary files `i18n/inasafe_es_ES.qm` and `i18n/inasafe_id.qm` also need updating, but I'm not sure how to do that/whether that is done by some other automated process.  If there are docs on how to do this, I can add to this PR.

